### PR TITLE
oskar/add_clean_to_npm_build

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   ],
   "license": "Apache License 2.0",
   "scripts": {
-    "build": "npm run test && gatsby clean && gatsby build --prefix-paths",
+    "build": "npm run test && gatsby clean && gatsby build",
     "develop": "gatsby develop -p 80",
     "format": "prettier --write '**/*.js' '*.js'",
     "stylelint": "stylelint 'src/**/*.js' --formatter verbose",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   ],
   "license": "Apache License 2.0",
   "scripts": {
-    "build": "npm run test && gatsby build --prefix-paths",
+    "build": "npm run test && gatsby clean && gatsby build --prefix-paths",
     "develop": "gatsby develop -p 80",
     "format": "prettier --write '**/*.js' '*.js'",
     "stylelint": "stylelint 'src/**/*.js' --formatter verbose",

--- a/src/pages/regulatory/index.js
+++ b/src/pages/regulatory/index.js
@@ -51,6 +51,7 @@ const FlexWrapper = styled(Container)`
 
     @media (max-width: 1249px) {
         justify-content: center;
+
         & > * {
             width: 100%;
             max-width: 50rem;


### PR DESCRIPTION
# Description

Wipe out .cache before build with `gatsby clean`
