### PR TITLE
amam/signup_link

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,4 +1,5 @@
-import React from 'react'
+import React, { useEffect } from 'react'
+import queryString from 'query-string'
 import { Hero } from './home/_hero'
 import { Trade } from './home/_trade'
 import { HowItWorks } from './home/_how-it-works'
@@ -10,32 +11,47 @@ import Ticker from './home/_ticker'
 import { SEO, Show } from 'components/containers'
 import Layout from 'components/layout/layout'
 import { localize, WithIntl } from 'components/localization'
-import { Divider } from 'components/elements'
+import { Divider, Modal, useModal } from 'components/elements'
+import SignupModal from 'components/custom/signup-modal'
 
-const Home = () => (
-    <Layout>
-        <SEO
-            title={localize('Your ultimate online trading experience')}
-            description={localize(
-                'Deriv is an online trading company that offers the broadest selection of derivatives with competitive prices.',
-            )}
-        />
-        <Hero />
-        <Show.Mobile>
-            <WhyDerivMobile />
-            <Trade />
-        </Show.Mobile>
-        <Show.Desktop>
-            <Ticker />
-            <Trade />
-            <Divider />
-            <HowItWorks />
-            <Divider />
-            <Markets />
-            <WhyDeriv />
-            <PaymentMethods />
-        </Show.Desktop>
-    </Layout>
-)
+const Home = () => {
+    const [show_modal, toggleModal, closeModal] = useModal()
+
+    useEffect(() => {
+        const parsedUrl = queryString.parse(window.location.search)
+        if (parsedUrl.action === 'signup') {
+            toggleModal()
+        }
+    }, [])
+
+    return (
+        <Layout>
+            <SEO
+                title={localize('Your ultimate online trading experience')}
+                description={localize(
+                    'Deriv is an online trading company that offers the broadest selection of derivatives with competitive prices.',
+                )}
+            />
+            <Hero />
+            <Show.Mobile>
+                <WhyDerivMobile />
+                <Trade />
+            </Show.Mobile>
+            <Show.Desktop>
+                <Ticker />
+                <Trade />
+                <Divider />
+                <HowItWorks />
+                <Divider />
+                <Markets />
+                <WhyDeriv />
+                <PaymentMethods />
+            </Show.Desktop>
+            <Modal toggle={toggleModal} is_open={show_modal} closeModal={closeModal}>
+                <SignupModal autofocus />
+            </Modal>
+        </Layout>
+    )
+}
 
 export default WithIntl()(Home)


### PR DESCRIPTION
# Description

will show signup modal when the querystring action is signup

Changes:

- add modal hooks to index
- use query-string to open modal

## Type of change

-   [ ] Bug fix
-   [x] New feature
-   [ ] Refactor code
-   [ ] Update translation text
-   [ ] Breaking change
-   [ ] Dependency update
-   [ ] This change requires a documentation update
-   [ ] Release
