### PR TITLE
amam/hide_ach_on_production

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -18,11 +18,7 @@ export const onInitialClientRender = () => {
 
         if (match_ach) {
             // TODO: remove this line when production ready for translation
-            if (isProduction()) {
-                navigate('/')
-            } else {
-                LocalStore.set('i18n', 'ach')
-            }
+            if (!isProduction()) LocalStore.set('i18n', 'ach')
         }
 
         const i18n = LocalStore.get('i18n')

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,3 +1,4 @@
+import { navigate } from 'gatsby'
 import { WrapPagesWithLocaleContext } from './src/components/localization'
 import { isProduction } from './src/common/websocket/config'
 import { LocalStore } from './src/common/storage'
@@ -13,10 +14,19 @@ export const onInitialClientRender = () => {
     // Check if not production and match ach or ach/
 
     if (is_browser) {
-        if (!isProduction() && window.location.pathname.match(/^(ach\/)|ach$/)) {
-            LocalStore.set('i18n', 'ach')
+        const match_ach = window.location.pathname.match(/^(\/ach\/)|\/ach$/)
+
+        if (match_ach) {
+            // TODO: remove this line when production ready for translation
+            if (isProduction()) {
+                navigate('/')
+            } else {
+                LocalStore.set('i18n', 'ach')
+            }
         }
+
         const i18n = LocalStore.get('i18n')
+
         if (!isProduction() && i18n && i18n.match('ach')) {
             const jipt = document.createElement('script')
             jipt.type = 'text/javascript'

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,4 +1,3 @@
-import { navigate } from 'gatsby'
 import { WrapPagesWithLocaleContext } from './src/components/localization'
 import { isProduction } from './src/common/websocket/config'
 import { LocalStore } from './src/common/storage'

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -9,10 +9,20 @@ exports.onCreatePage = ({ page, actions }) => {
     // So everything in src/pages/
     deletePage(page)
 
+    // Checking env variables
+    // eslint-disable-next-line no-console
+    console.log(process.env.GATSBY_ENV)
+
     Object.keys(language_config).map(lang => {
         // Use the values defined in "locales" to construct the path
         const { path, is_default } = language_config[lang]
         const localized_path = is_default ? page.path : `${path}${page.path}`
+        const is_production = process.env.GATSBY_ENV === 'production'
+
+        // TODO: remove this after production ready for translation
+        if (is_production) {
+            if (path === 'ach') return
+        }
 
         return createPage({
             // Pass on everything from the original page

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -9,10 +9,6 @@ exports.onCreatePage = ({ page, actions }) => {
     // So everything in src/pages/
     deletePage(page)
 
-    // Checking env variables
-    // eslint-disable-next-line no-console
-    console.log(process.env.GATSBY_ENV)
-
     Object.keys(language_config).map(lang => {
         // Use the values defined in "locales" to construct the path
         const { path, is_default } = language_config[lang]

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -19,7 +19,6 @@ exports.onCreatePage = ({ page, actions }) => {
         const localized_path = is_default ? page.path : `${path}${page.path}`
         const is_production = process.env.GATSBY_ENV === 'production'
 
-        // TODO: remove this after production ready for translation
         if (is_production) {
             if (path === 'ach') return
         }

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,8 @@
+[context.production.environment]
+  GATSBY_ENV = "production"
+# deploy preview
+[context.deploy-preview.environment]
+  GATSBY_ENV = "deploy" # TEST: should be deploy or something other than production
+# branch-deploy (other than previews)
+[context.branch-deploy.environment]
+  GATSBY_ENV = "development"


### PR DESCRIPTION
# Description

hide ach on production

Changes:

- match production in gatsby-browser
- if it is, navigate to homepage default ('/')

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Refactor code
-   [ ] Update translation text
-   [ ] Breaking change
-   [ ] Dependency update
-   [ ] This change requires a documentation update
-   [ ] Release
