### PR TITLE
oskar/update_sitemap_exclude_patterns

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -23,14 +23,7 @@ module.exports = {
         {
             resolve: 'gatsby-plugin-sitemap',
             options: {
-                exclude: [
-                    '/404',
-                    '/*/404',
-                    '/404.html',
-                    '/*/404.html',
-                    '/check-email',
-                    '/*/check-email',
-                ],
+                exclude: ['/404', '/**/404.html', '/**/404', '/check-email', '/**/check-email'],
             },
         },
         'gatsby-plugin-remove-serviceworker',


### PR DESCRIPTION
## Description
Fix exclusion pattern to exclude `404` and `check-email` from sitemap

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Refactor code
-   [ ] Update translation text
-   [ ] Breaking change
-   [ ] Dependency update
-   [ ] This change requires a documentation update
-   [ ] Release
