### PR TITLE
amam/main_100

### DIFF
--- a/src/components/layout/layout.js
+++ b/src/components/layout/layout.js
@@ -7,7 +7,7 @@ import { Nav, NavStatic } from './nav'
 const Main = styled.main`
     padding-top: 7rem;
     background: var(--color-white);
-    ${props => (props.is_static ? '92vh' : '100%')}
+    height: ${props => (props.is_static ? '92vh' : '100%')};
 `
 
 const Layout = ({ children, is_static }) => (

--- a/src/components/layout/layout.js
+++ b/src/components/layout/layout.js
@@ -7,13 +7,13 @@ import { Nav, NavStatic } from './nav'
 const Main = styled.main`
     padding-top: 7rem;
     background: var(--color-white);
-    height: 100%;
+    ${props => (props.is_static ? '92vh' : '100%')}
 `
 
 const Layout = ({ children, is_static }) => (
     <>
         {is_static ? <NavStatic /> : <Nav />}
-        <Main>{children}</Main>
+        <Main is_static={is_static}>{children}</Main>
         {!is_static && <Footer />}
     </>
 )

--- a/src/components/layout/layout.js
+++ b/src/components/layout/layout.js
@@ -7,6 +7,7 @@ import { Nav, NavStatic } from './nav'
 const Main = styled.main`
     padding-top: 7rem;
     background: var(--color-white);
+    height: 100%;
 `
 
 const Layout = ({ children, is_static }) => (


### PR DESCRIPTION
# Description

main should be 100% height, to not show background body on short page

Changes:

- alter main on layout -> height: 100%

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Refactor code
-   [ ] Update translation text
-   [ ] Breaking change
-   [ ] Dependency update
-   [ ] This change requires a documentation update
-   [ ] Release
