### PR TITLE
amam/set_affiliate

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -36,6 +36,7 @@ export const onInitialClientRender = () => {
 
     // Configure traffic source
     TrafficSource.setData()
+    TrafficSource.setAffiliateData()
 
     if (!LocalStore.get('signup_device')) {
         LocalStore.set('signup_device', isMobile() ? 'mobile' : 'desktop')

--- a/src/common/login.js
+++ b/src/common/login.js
@@ -29,7 +29,7 @@ const Login = (() => {
             ? `&utm_campaign=${utm_data.utm_campaign}`
             : ''
         const affiliate_token_link = affiliate_tracking
-            ? `&affiliate_token=${affiliate_tracking.t}`
+            ? `&affiliate_token=${affiliate_tracking}`
             : ''
         const deriv_app_app_id = 16929
 

--- a/src/common/traffic-source.js
+++ b/src/common/traffic-source.js
@@ -18,10 +18,14 @@ const TrafficSource = (() => {
     const setAffiliateData = () => {
         const url_params = queryString.parseUrl(window.location.href).query
         const token = url_params.t
+
+        if (!token) return false
+
         const token_length = token.length
         const binary_token_length = 32
 
-        if (!token || token_length !== binary_token_length) {
+        // Check if token length is correct
+        if (token_length !== binary_token_length) {
             return false
         }
 

--- a/src/common/traffic-source.js
+++ b/src/common/traffic-source.js
@@ -1,4 +1,3 @@
-import Cookies from 'js-cookie'
 import queryString from 'query-string'
 import { CookieStorage, LocalStore } from './storage'
 
@@ -18,6 +17,7 @@ const TrafficSource = (() => {
     const setAffiliateData = () => {
         const url_params = queryString.parseUrl(window.location.href).query
         const token = url_params.t
+        const affiliate_cookie = new CookieStorage('affiliate_tracking')
 
         if (!token) return false
 
@@ -29,7 +29,7 @@ const TrafficSource = (() => {
             return false
         }
 
-        const affiliate_token = Cookies.getJSON('affiliate_tracking')
+        const affiliate_token = affiliate_cookie.get('affiliate_tracking')
         if (affiliate_token) {
             // Affiliate token already exists in the cookies
             if (affiliate_token === token) {
@@ -37,14 +37,7 @@ const TrafficSource = (() => {
             }
         }
 
-        Cookies.write('affiliate_tracking', token.toString(), {
-            expires: 365, // expires in 365 days
-            path: '/',
-            domain: `.${location.hostname
-                .split('.')
-                .slice(-2)
-                .join('.')}`,
-        })
+        affiliate_cookie.write(token, 365)
         return true
     }
 

--- a/src/common/traffic-source.js
+++ b/src/common/traffic-source.js
@@ -18,31 +18,22 @@ const TrafficSource = (() => {
     const setAffiliateData = () => {
         const url_params = queryString.parseUrl(window.location.href).query
         const token = url_params.t
-        if (!token || token.length !== 32) {
+        const token_length = token.length
+        const binary_token_length = 32
+
+        if (!token || token_length !== binary_token_length) {
             return false
         }
 
-        const token_length = token.length
-        const is_subsidiary = /\w{1}/.test(url_params.s)
-
-        const cookie_token = Cookies.getJSON('affiliate_tracking')
-        if (cookie_token) {
-            // Already exposed to some other affiliate.
-            if (is_subsidiary && cookie_token && cookie_token.t) {
+        const affiliate_token = Cookies.getJSON('affiliate_tracking').toString()
+        if (affiliate_token) {
+            // Affiliate token already exists in the cookies
+            if (affiliate_token === token) {
                 return false
             }
         }
 
-        // Record the affiliate exposure. Overwrite existing cookie, if any.
-        const cookie_hash = {}
-        if (token_length === 32) {
-            cookie_hash.t = token.toString()
-        }
-        if (is_subsidiary) {
-            cookie_hash.s = '1'
-        }
-
-        Cookies.write('affiliate_tracking', cookie_hash, {
+        Cookies.write('affiliate_tracking', affiliate_token, {
             expires: 365, // expires in 365 days
             path: '/',
             domain: `.${location.hostname

--- a/src/common/traffic-source.js
+++ b/src/common/traffic-source.js
@@ -29,7 +29,7 @@ const TrafficSource = (() => {
             return false
         }
 
-        const affiliate_token = Cookies.getJSON('affiliate_tracking').toString()
+        const affiliate_token = Cookies.getJSON('affiliate_tracking')
         if (affiliate_token) {
             // Affiliate token already exists in the cookies
             if (affiliate_token === token) {
@@ -37,7 +37,7 @@ const TrafficSource = (() => {
             }
         }
 
-        Cookies.write('affiliate_tracking', affiliate_token, {
+        Cookies.write('affiliate_tracking', token.toString(), {
             expires: 365, // expires in 365 days
             path: '/',
             domain: `.${location.hostname

--- a/src/components/custom/signup.js
+++ b/src/components/custom/signup.js
@@ -133,7 +133,7 @@ class Signup extends Component {
                     utm_medium: utm_data.utm_medium,
                     utm_campaign: utm_data.utm_campaign,
                 }),
-                ...(affiliate_token && { affiliate_token: affiliate_token.t }),
+                ...(affiliate_token && { affiliate_token: affiliate_token }),
                 ...(gclid && { gclid_url: gclid }),
                 ...(signup_device && { signup_device: signup_device }),
                 ...(date_first_contact && {


### PR DESCRIPTION
# Description

add affiliate token in traffic js when the page loads

Changes:

-  set affiliate token in page initial render, expires in 1 year

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Refactor code
-   [ ] Update translation text
-   [ ] Breaking change
-   [ ] Dependency update
-   [ ] This change requires a documentation update
-   [ ] Release
