### PR TITLE
amam/fix_eu_render_issue

### DIFF
--- a/src/components/containers/show.js
+++ b/src/components/containers/show.js
@@ -28,16 +28,16 @@ export const Mobile = ({ children, ...props }) => (
 )
 
 export const Eu = ({ children }) => {
-    const { is_eu } = React.useContext(LocationContext)
+    const { is_eu_country } = React.useContext(LocationContext)
 
-    if (is_eu) return <>{children}</>
+    if (is_eu_country) return <>{children}</>
     else return null
 }
 
 export const NonEU = ({ children }) => {
-    const { is_eu } = React.useContext(LocationContext)
+    const { is_eu_country } = React.useContext(LocationContext)
 
-    if (is_eu === false) return <>{children}</>
+    if (is_eu_country === false) return <>{children}</>
     else return null
 }
 


### PR DESCRIPTION
# Description

Fix typo on Show.Eu component

Changes:

- use `is_eu_country` instead of `is_eu`

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Refactor code
-   [ ] Update translation text
-   [ ] Breaking change
-   [ ] Dependency update
-   [ ] This change requires a documentation update
-   [ ] Release
