### PR TITLE
suthesh/fix_tab_orientation

### DIFF
--- a/src/pages/terms-and-conditions/index.js
+++ b/src/pages/terms-and-conditions/index.js
@@ -44,7 +44,7 @@ const TermsAndConditions = () => {
                     </Flex>
                 </Container>
                 <TabWrapper>
-                    <Tabs tab_break="500px">
+                    <Tabs>
                         <Tabs.Panel label={localize('FOR CLIENTS')}>
                             <CustomerGrid />
                         </Tabs.Panel>


### PR DESCRIPTION
# Description

Tabs set to always be in row orientation

Changes:

-   Tabs set to always be in row orientation

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Refactor code
-   [ ] Update translation text
-   [ ] Breaking change
-   [ ] Dependency update
-   [ ] This change requires a documentation update
-   [ ] Release
