### PR TITLE
fix layout in synthetic indices  market page for margin and multipliers

### DIFF
--- a/src/pages/markets/synthetic/_digital-options.js
+++ b/src/pages/markets/synthetic/_digital-options.js
@@ -32,7 +32,7 @@ const Col = styled(Flex)`
     max-width: 13.2rem;
 
     @media ${device.tabletL} {
-        max-width: 10rem;
+        max-width: 12rem;
     }
 `
 const MarketsWrapper = styled(Flex)`
@@ -74,7 +74,7 @@ const MarketsList = styled(CssGrid)`
     border-right: 1px solid var(--color-grey-22);
     grid-template-columns: repeat(3, 1fr);
     width: 100%;
-    padding: 2.4rem 1.6rem;
+    padding: 2.4rem 0.7rem;
     grid-row-gap: 1.6rem;
 
     @media ${device.tabletL} {
@@ -94,7 +94,6 @@ const MarketsList = styled(CssGrid)`
 const Title = styled(Text)`
     @media ${device.tabletL} {
         text-align: center;
-        max-width: 8rem;
         font-weight: 600;
     }
 `

--- a/src/pages/markets/synthetic/_margin.js
+++ b/src/pages/markets/synthetic/_margin.js
@@ -57,7 +57,6 @@ const MarketsList = styled(CssGrid)`
 const Title = styled(Text)`
     @media ${device.tabletL} {
         text-align: center;
-        max-width: 6.4rem;
         font-weight: 600;
     }
 `

--- a/src/pages/markets/synthetic/_multipliers.js
+++ b/src/pages/markets/synthetic/_multipliers.js
@@ -15,7 +15,7 @@ const Col = styled(Flex)`
     max-width: 13.2rem;
 
     @media ${device.tabletL} {
-        max-width: 10rem;
+        max-width: 12rem;
     }
 `
 const MarketsWrapper = styled(Flex)`
@@ -37,7 +37,7 @@ const MarketsList = styled(CssGrid)`
     border-right: 1px solid var(--color-grey-22);
     grid-template-columns: repeat(3, 1fr);
     width: 100%;
-    padding: 2.4rem 1.6rem;
+    padding: 2.4rem 0.7rem;
     grid-row-gap: 1.6rem;
 
     @media ${device.tabletL} {
@@ -58,7 +58,6 @@ const MarketsList = styled(CssGrid)`
 const Title = styled(Text)`
     @media ${device.tabletL} {
         text-align: center;
-        max-width: 8rem;
         font-weight: 600;
     }
 `
@@ -116,7 +115,7 @@ const Multipliers = () => {
                         renderTitle={() => (
                             <Row jc="flex-start" ai="center">
                                 <Col>
-                                    <Title weight="bold" align="center" p="0 0.4rem">
+                                    <Title weight="bold" align="center">
                                         {localize('Continuous indices')}
                                     </Title>
                                 </Col>


### PR DESCRIPTION
# Description

Fix layout in synthetic indices market page

Changes:

-   Increase width for synthetic indices market page for margin and multipliers

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
