### PR TITLE
sean/fix-signup-social-button-gap-mobile

### DIFF
--- a/src/components/custom/_signup-new.js
+++ b/src/components/custom/_signup-new.js
@@ -108,6 +108,11 @@ const SocialButton = styled(Button)`
         width: 20rem;
         height: 6rem;
     }
+    @media ${device.mobileS} {
+        &:first-child {
+            margin-right: 0.8rem;
+        }
+    }
 `
 
 const SocialWrapper = styled.div`

--- a/src/components/custom/_signup-new.js
+++ b/src/components/custom/_signup-new.js
@@ -108,9 +108,9 @@ const SocialButton = styled(Button)`
         width: 20rem;
         height: 6rem;
     }
-    @media ${device.mobileS} {
+    @media ${device.mobileM} {
         &:first-child {
-            margin-right: 0.8rem;
+            margin-right: 1.2rem;
         }
     }
 `


### PR DESCRIPTION
# Description

Summary
Added a gap between the social buttons on the signup page to match the design.

Changes:

-  Added a margin right to the first social button

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
