### PR TITLE
amam/add check for p2p allowed country

### DIFF
--- a/src/common/country-base.js
+++ b/src/common/country-base.js
@@ -31,6 +31,40 @@ const eu_countries = [
     'mt',
 ]
 
+const p2p_allowed_countries = [
+    'ng',
+    'za',
+    'zw',
+    'tz',
+    'gh',
+    'zm',
+    'bw',
+    'na',
+    'ke',
+    'aq',
+    'so',
+    'pk',
+    'in',
+    'bd',
+    'ik',
+    'ci',
+    'ar',
+    'bo',
+    'cl',
+    'co',
+    'ec',
+    'gf',
+    'gy',
+    'py',
+    'pe',
+    'sr',
+    'uy',
+    've',
+]
+
 export const isEuCountry = (clients_country) => eu_countries.includes(clients_country)
+
+export const isP2PAllowedCountry = (clients_country) =>
+    p2p_allowed_countries.includes(clients_country)
 
 export const isUK = (clients_country) => clients_country === 'gb'

--- a/src/pages/payment-methods/index.js
+++ b/src/pages/payment-methods/index.js
@@ -191,6 +191,7 @@ DisplayAccordianItem.propTypes = {
 }
 
 const PaymentMethods = () => {
+    const { is_p2p_allowed_country } = React.useContext(DerivStore)
     return (
         <Layout>
             <Helmet>
@@ -229,12 +230,16 @@ const PaymentMethods = () => {
                     </Text>
                 </Container>
             </SectionContainer>
-            <Divider height="2px" />
-            <SectionContainer>
-                <Container direction="column">
-                    <Dp2p />
-                </Container>
-            </SectionContainer>
+            {is_p2p_allowed_country && (
+                <>
+                    <Divider height="2px" />
+                    <SectionContainer>
+                        <Container direction="column">
+                            <Dp2p />
+                        </Container>
+                    </SectionContainer>
+                </>
+            )}
         </Layout>
     )
 }

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,19 +1,20 @@
 import React, { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import { useWebsiteStatus } from 'components/hooks/website-status-hooks'
-import { isEuCountry } from 'common/country-base'
+import { isEuCountry, isP2PAllowedCountry } from 'common/country-base'
 
 export const DerivStore = React.createContext()
 
 export const DerivProvider = ({ children }) => {
     const [website_status] = useWebsiteStatus()
     const [is_eu_country, setEuCountry] = useState(false)
+    const [is_p2p_allowed_country, setP2PAllowedCountry] = useState(false)
     const [crypto_config, setCryptoConfig] = useState(null)
 
     useEffect(() => {
         if (website_status) {
             setEuCountry(isEuCountry(website_status.clients_country))
-
+            setP2PAllowedCountry(isP2PAllowedCountry(website_status.clients_country))
             if (!crypto_config) {
                 setCryptoConfig(website_status.crypto_config)
             }
@@ -24,6 +25,7 @@ export const DerivProvider = ({ children }) => {
         <DerivStore.Provider
             value={{
                 is_eu_country,
+                is_p2p_allowed_country,
                 crypto_config,
             }}
         >


### PR DESCRIPTION
Changes:

- payment method p2p only available if the client is from p2p allowed country

## Type of change

-   [ ] Bug fix
-   [x] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
