### PR TITLE
Kevin/feat: update calculator scroll and anchor hash link

### DIFF
--- a/src/pages/trade-types/margin/_policies.js
+++ b/src/pages/trade-types/margin/_policies.js
@@ -117,7 +117,7 @@ const Policies = () => {
                             <InfoWrapper>
                                 <img src={Info} alt="info" />
                             </InfoWrapper>
-                            <Header as="h4">
+                            <Header as="h4" id="swap-policy">
                                 {localize('Important notes on our swap rates (overnight funding)')}
                             </Header>
                         </CardHeading>

--- a/src/pages/trader-tools/_style.js
+++ b/src/pages/trader-tools/_style.js
@@ -184,6 +184,27 @@ export const CalculatorOutputSymbol = styled.label`
 
 export const CalculatorBody = styled.div`
     padding: 2.4rem;
+<<<<<<< HEAD
+=======
+    /* stylelint-disable property-no-vendor-prefix */
+    ul::-webkit-scrollbar {
+        width: 13px;
+        height: 80px;
+    }
+    ul::-webkit-scrollbar-thumb {
+        border: 4px solid rgba(0, 0, 0, 0);
+        background-clip: padding-box;
+        -webkit-border-radius: 7px;
+        border-radius: 7px;
+        background-color: var(--color-grey-32);
+        -webkit-box-shadow: inset -1px -1px 0 rgba(0, 0, 0, 0.05),
+            inset 1px 1px 0 rgba(0, 0, 0, 0.05);
+        box-shadow: inset -1px -1px 0 rgba(0, 0, 0, 0.05), inset 1px 1px 0 rgba(0, 0, 0, 0.05);
+    }
+    ul::-webkit-scrollbar-corner {
+        background-color: transparent;
+    }
+>>>>>>> feat: update scroll and anchor hash link
 `
 
 export const CalculatorTabItem = styled.div`

--- a/src/pages/trader-tools/_style.js
+++ b/src/pages/trader-tools/_style.js
@@ -188,8 +188,7 @@ export const CalculatorBody = styled.div`
 =======
     /* stylelint-disable property-no-vendor-prefix */
     ul::-webkit-scrollbar {
-        width: 13px;
-        height: 80px;
+        width: 12px;
     }
     ul::-webkit-scrollbar-thumb {
         border: 4px solid rgba(0, 0, 0, 0);

--- a/src/pages/trader-tools/_style.js
+++ b/src/pages/trader-tools/_style.js
@@ -184,8 +184,6 @@ export const CalculatorOutputSymbol = styled.label`
 
 export const CalculatorBody = styled.div`
     padding: 2.4rem;
-<<<<<<< HEAD
-=======
     /* stylelint-disable property-no-vendor-prefix */
     ul::-webkit-scrollbar {
         width: 12px;
@@ -203,7 +201,6 @@ export const CalculatorBody = styled.div`
     ul::-webkit-scrollbar-corner {
         background-color: transparent;
     }
->>>>>>> feat: update scroll and anchor hash link
 `
 
 export const CalculatorTabItem = styled.div`

--- a/src/pages/trader-tools/_swap-calculator.js
+++ b/src/pages/trader-tools/_swap-calculator.js
@@ -535,7 +535,11 @@ const SwapCalculator = () => {
                                 <StyledLinkButton
                                     external
                                     secondary="true"
+<<<<<<< HEAD
                                     to="/trade-types/margin"
+=======
+                                    to="/trade-types/margin#swap-policy"
+>>>>>>> feat: update scroll and anchor hash link
                                 >
                                     {localize('Learn more about swaps')}
                                 </StyledLinkButton>
@@ -848,7 +852,15 @@ const SwapCalculator = () => {
                             >
                                 {localize('Go to DMT5 dashboard')}
                             </StyledLinkButton>
+<<<<<<< HEAD
                             <StyledLinkButton external secondary="true" to="/trade-types/margin">
+=======
+                            <StyledLinkButton
+                                external
+                                secondary="true"
+                                to="/trade-types/margin#swap-policy"
+                            >
+>>>>>>> feat: update scroll and anchor hash link
                                 {localize('Learn more about swaps')}
                             </StyledLinkButton>
                         </LinkWrapper>

--- a/src/pages/trader-tools/_swap-calculator.js
+++ b/src/pages/trader-tools/_swap-calculator.js
@@ -535,11 +535,7 @@ const SwapCalculator = () => {
                                 <StyledLinkButton
                                     external
                                     secondary="true"
-<<<<<<< HEAD
-                                    to="/trade-types/margin"
-=======
                                     to="/trade-types/margin#swap-policy"
->>>>>>> feat: update scroll and anchor hash link
                                 >
                                     {localize('Learn more about swaps')}
                                 </StyledLinkButton>
@@ -852,15 +848,11 @@ const SwapCalculator = () => {
                             >
                                 {localize('Go to DMT5 dashboard')}
                             </StyledLinkButton>
-<<<<<<< HEAD
-                            <StyledLinkButton external secondary="true" to="/trade-types/margin">
-=======
                             <StyledLinkButton
                                 external
                                 secondary="true"
                                 to="/trade-types/margin#swap-policy"
                             >
->>>>>>> feat: update scroll and anchor hash link
                                 {localize('Learn more about swaps')}
                             </StyledLinkButton>
                         </LinkWrapper>

--- a/src/themes/variables.js
+++ b/src/themes/variables.js
@@ -49,6 +49,7 @@ const Variables = css`
         --color-grey-29: #edeeef;
         --color-grey-30: #f5f7fa;
         --color-grey-31: #f8fafc;
+        --color-grey-32: #dcdee0;
         --color-green: #85acb0;
         --color-blue: #4c76be;
         --color-blue-2: #365899;


### PR DESCRIPTION
# Description

Summary

Changes:

-   css webkit for scroll styling
-  swap calculator `learn more button` to target anchor hash on to margin - swap

## Type of change

-   [ ] Bug fix
-   [x] New feature
-   [x] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
