### PR TITLE
yashim/fix: markets page not loading from top & bouncy navigation

### DIFF
--- a/src/common/utility.js
+++ b/src/common/utility.js
@@ -57,7 +57,7 @@ const setLocationHash = (tab) => {
 }
 
 const routeBack = () => {
-    if (isBrowser) {
+    if (isBrowser()) {
         window.history.back()
     }
 }

--- a/src/common/utility.js
+++ b/src/common/utility.js
@@ -27,10 +27,9 @@ const isEmptyObject = (obj) => {
 }
 
 const scrollTop = () => {
-    if (isBrowser()) {
-        document.body.scrollTop = 0
-        document.documentElement.scrollTop = 0
-    }
+    if (!isBrowser) return
+    document.body.scrollTop = 0
+    document.documentElement.scrollTop = 0
 }
 
 const cloneObject = (obj) =>
@@ -49,10 +48,14 @@ const getLocationHash = () =>
     isBrowser() && location.hash ? location.hash.slice(1).replace(/(\/)$/g, '') : ''
 
 const setLocationHash = (tab) => {
-    if (isBrowser()) {
+    if (!isBrowser) return
+    if (history.pushState) {
+        history.pushState(null, null, `#${tab}`)
+    } else {
         location.hash = `#${tab}`
     }
 }
+
 const routeBack = () => {
     if (isBrowser) {
         window.history.back()

--- a/src/components/hooks/use-tab-state.js
+++ b/src/components/hooks/use-tab-state.js
@@ -10,19 +10,17 @@ import {
 
 export const useTabState = (tab_list) => {
     const [active_tab, setActiveTab] = useState('')
-    const handleHashChange = () => {
-        document.preventDefault()
-    }
+    const handleHashChange = () => document.preventDefault()
 
     useEffect(() => {
+        document.addEventListener('hashchange', handleHashChange)
+
         if (checkElemInArray(tab_list, getLocationHash())) {
             setActiveTab(getLocationHash())
             scrollTop()
         } else {
             setActiveTab(tab_list[0])
         }
-
-        document.addEventListener('hashchange', handleHashChange)
 
         return () => {
             document.removeEventListener('hashchange', handleHashChange)

--- a/src/components/hooks/use-tab-state.js
+++ b/src/components/hooks/use-tab-state.js
@@ -1,15 +1,31 @@
 import { useState, useEffect } from 'react'
-import { checkElemInArray, getLocationHash, isBrowser, routeBack, scrollTop, setLocationHash } from 'common/utility'
+import {
+    checkElemInArray,
+    getLocationHash,
+    isBrowser,
+    routeBack,
+    scrollTop,
+    setLocationHash,
+} from 'common/utility'
 
 export const useTabState = (tab_list) => {
-    const [active_tab, setActiveTab] = useState(getLocationHash() && checkElemInArray(tab_list, getLocationHash()) ? getLocationHash() : tab_list[0])
+    const [active_tab, setActiveTab] = useState('')
+    const handleHashChange = () => {
+        document.preventDefault()
+    }
 
     useEffect(() => {
-        if (!getLocationHash() || !checkElemInArray(tab_list, getLocationHash())) {
-            setLocationHash(active_tab)
-        } else {
+        if (checkElemInArray(tab_list, getLocationHash())) {
             setActiveTab(getLocationHash())
             scrollTop()
+        } else {
+            setActiveTab(tab_list[0])
+        }
+
+        document.addEventListener('hashchange', handleHashChange)
+
+        return () => {
+            document.removeEventListener('hashchange', handleHashChange)
         }
     }, [])
 
@@ -20,10 +36,10 @@ export const useTabState = (tab_list) => {
     }, [active_tab])
 
     useEffect(() => {
-        if (getLocationHash() !== active_tab && checkElemInArray(tab_list, getLocationHash())) {
+        if (getLocationHash() === active_tab) return
+        if (checkElemInArray(tab_list, getLocationHash())) {
             setActiveTab(getLocationHash())
-            scrollTop()
-        } else if (!checkElemInArray(tab_list, getLocationHash())) {
+        } else {
             routeBack()
         }
     }, [getLocationHash()])


### PR DESCRIPTION
# Description

Summary
- Clicking Markets -> Forex/Any Pages will always scroll to the [Page] anchor. Eg; if the page selected is Market -> Forex, user's browser window will directly scroll to the forex page.
- Navigating in between tabs will cause up and down scroll effect (bouncy).

Changes:
- Prevented the default behaviour of location.hash change.
- Prevented location hash change from triggering scroll to hash location.
- Refactored useTabState hook

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
