### PR TITLE
yashim/fix: Image quality of hero banner in career location pages

### DIFF
--- a/src/components/graphql/fragments.js
+++ b/src/components/graphql/fragments.js
@@ -3,7 +3,7 @@ import { graphql } from 'gatsby'
 export const backGroundBlur = graphql`
     fragment backGroundBlur on File {
         childImageSharp {
-            fluid(maxWidth: 1024, srcSetBreakpoints: [600, 1440]) {
+            fluid(quality: 90, maxWidth: 2048, srcSetBreakpoints: [600, 1440]) {
                 ...GatsbyImageSharpFluid_withWebp
                 originalName
             }


### PR DESCRIPTION
# Description

Summary
- Fixed low quality image in career location hero banner.

Changes:
- By default, if unspecified, Gatsby will set an image quality of 50%. Increased to 90% with a max width of double (2048 px).

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
