### PR TITLE
Yashim/fix underline navbar

### DIFF
--- a/src/components/custom/other-platforms.js
+++ b/src/components/custom/other-platforms.js
@@ -13,7 +13,7 @@ import {
 } from 'components/elements'
 import { localize, LocalizedLink, Localize } from 'components/localization'
 import device from 'themes/device'
-import { community_url, isBrowser } from 'common/utility'
+import { community_url, getLocationHash } from 'common/utility'
 // icons
 import DTrader from 'images/svg/dtrader-icon.svg'
 import DMT5 from 'images/svg/dmt5-icon.svg'
@@ -336,7 +336,7 @@ export const NavMarket = ({ onClick, setCurrentPage }) => {
     useEffect(() => {
         if (Object.values(links).includes(window.location.pathname + window.location.hash))
             setCurrentPage('markets')
-    }, [isBrowser() ? window.location.hash : null])
+    }, [getLocationHash()])
 
     return (
         <Flex direction="column" wrap="wrap" jc="flex-start">
@@ -401,7 +401,7 @@ export const NavCompany = ({ onClick, setCurrentPage }) => {
     useEffect(() => {
         if (Object.values(links).includes(window.location.pathname + window.location.hash))
             setCurrentPage('company')
-    }, [isBrowser() ? window.location.hash : null])
+    }, [getLocationHash()])
 
     return (
         <Flex direction="column" wrap="wrap" jc="flex-start" max_width="42rem">

--- a/src/components/custom/other-platforms.js
+++ b/src/components/custom/other-platforms.js
@@ -13,7 +13,7 @@ import {
 } from 'components/elements'
 import { localize, LocalizedLink, Localize } from 'components/localization'
 import device from 'themes/device'
-import { community_url } from 'common/utility'
+import { community_url, isBrowser } from 'common/utility'
 // icons
 import DTrader from 'images/svg/dtrader-icon.svg'
 import DMT5 from 'images/svg/dmt5-icon.svg'
@@ -336,7 +336,7 @@ export const NavMarket = ({ onClick, setCurrentPage }) => {
     useEffect(() => {
         if (Object.values(links).includes(window.location.pathname + window.location.hash))
             setCurrentPage('markets')
-    }, [window?.location.hash])
+    }, [isBrowser() ? window.location.hash : null])
 
     return (
         <Flex direction="column" wrap="wrap" jc="flex-start">
@@ -389,8 +389,8 @@ NavMarket.propTypes = {
 
 export const NavCompany = ({ onClick, setCurrentPage }) => {
     const links = {
-        story: '/about/#story',
-        leadership: '/about/#leadership',
+        story: '/about#story',
+        leadership: '/about#leadership',
         regulatory: '/regulatory/',
         choose: '/why-choose-us/',
         partners: '/partners/',
@@ -401,7 +401,7 @@ export const NavCompany = ({ onClick, setCurrentPage }) => {
     useEffect(() => {
         if (Object.values(links).includes(window.location.pathname + window.location.hash))
             setCurrentPage('company')
-    }, [window?.location.hash])
+    }, [isBrowser() ? window.location.hash : null])
 
     return (
         <Flex direction="column" wrap="wrap" jc="flex-start" max_width="42rem">

--- a/src/components/custom/other-platforms.js
+++ b/src/components/custom/other-platforms.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import PropTypes from 'prop-types'
 import styled, { css } from 'styled-components'
 import { SectionContainer, Flex, FlexGridContainer } from 'components/containers'
@@ -224,226 +224,289 @@ OtherPlatform.propTypes = {
     subHeader: PropTypes.string,
 }
 
-export const NavPlatform = ({ onClick }) => (
-    <Flex>
-        <Flex direction="column" wrap="wrap" jc="flex-start">
-            <StyledText>{localize('Trading platforms')}</StyledText>
-            <NavCard
-                icon={() => <img src={DTrader} alt="Dtrader" width="32" height="32" />}
-                content={
-                    <Localize translate_text="A whole new trading experience on a powerful yet easy to use platform." />
-                }
-                title={<Localize translate_text="DTrader" />}
-                onClick={onClick}
-                to="/dtrader"
-            />
-            <NavCard
-                icon={() => <img src={DBot} alt="DBot" width="32" height="32" />}
-                content={
-                    <Localize translate_text="Automated trading at your fingertips. No coding needed." />
-                }
-                title={<Localize translate_text="DBot" />}
-                onClick={onClick}
-                to="/dbot"
-            />
-            <NavCard
-                icon={() => <img src={DMT5} alt="DMT5" width="32" height="32" />}
-                content={
-                    <Localize translate_text="Trade on Deriv MetaTrader 5 (DMT5), the all-in-one FX and CFD trading platform." />
-                }
-                title={<Localize translate_text="DMT5" />}
-                onClick={onClick}
-                to="/dmt5"
-            />
-            <NavCard
-                icon={() => <img src={Smarttrader} alt="Smarttrader" width="32" height="32" />}
-                content={
-                    <Localize translate_text="Trade the world’s markets with our popular user-friendly platform." />
-                }
-                title={<Localize translate_text="SmartTrader" />}
-                to="trading"
-                is_smarttrader_link
-                external="true"
-                target="_blank"
-                onClick={onClick}
-                otherLinkProps={{ rel: 'noopener noreferrer' }}
-            />
-        </Flex>
-        <MarginDivider width="2px" height="100%" color="grey-8" />
-        <Flex direction="column" wrap="wrap" jc="flex-start">
-            <StyledText>{localize('Trade types')}</StyledText>
-            <NavCard
-                icon={() => <img src={Margin} alt="Margin" width="32" height="32" />}
-                content={
-                    <Localize translate_text="Trade with leverage and low spreads for better returns on successful trades." />
-                }
-                title={<Localize translate_text="Margin trading" />}
-                onClick={onClick}
-                to="/trade-types/margin"
-            />
+export const NavPlatform = ({ onClick, setCurrentPage }) => {
+    const links = {
+        dtrader: '/dtrader',
+        dbot: '/dbot',
+        dmt5: '/dmt5',
+        smarttrader: 'trading',
+        margin: '/trade-types/margin',
+        options: '/trade-types/options',
+        multipliers: '/trade-types/multiplier',
+    }
 
-            <NavCard
-                icon={() => <img src={Options} alt="Options" width="32" height="32" />}
-                content={
-                    <Localize translate_text="Earn fixed payouts by predicting an asset's price movement." />
-                }
-                title={<Localize translate_text="Options" />}
-                onClick={onClick}
-                to="/trade-types/options"
-            />
-            <NavCard
-                icon={() => <img src={Multipliers} alt="Multipliers" width="32" height="32" />}
-                content={
-                    <Localize translate_text="Combine the upside of margin trading with the simplicity of options." />
-                }
-                title={<Localize translate_text="Multipliers" />}
-                onClick={onClick}
-                to="/trade-types/multiplier"
-            />
+    useEffect(() => {
+        if (Object.values(links).includes(window.location.pathname)) setCurrentPage('trade')
+    }, [])
+
+    return (
+        <Flex>
+            <Flex direction="column" wrap="wrap" jc="flex-start">
+                <StyledText>{localize('Trading platforms')}</StyledText>
+                <NavCard
+                    icon={() => <img src={DTrader} alt="Dtrader" width="32" height="32" />}
+                    content={
+                        <Localize translate_text="A whole new trading experience on a powerful yet easy to use platform." />
+                    }
+                    title={<Localize translate_text="DTrader" />}
+                    onClick={onClick}
+                    to={links.dbot}
+                />
+                <NavCard
+                    icon={() => <img src={DBot} alt="DBot" width="32" height="32" />}
+                    content={
+                        <Localize translate_text="Automated trading at your fingertips. No coding needed." />
+                    }
+                    title={<Localize translate_text="DBot" />}
+                    onClick={onClick}
+                    to={links.dbot}
+                />
+                <NavCard
+                    icon={() => <img src={DMT5} alt="DMT5" width="32" height="32" />}
+                    content={
+                        <Localize translate_text="Trade on Deriv MetaTrader 5 (DMT5), the all-in-one FX and CFD trading platform." />
+                    }
+                    title={<Localize translate_text="DMT5" />}
+                    onClick={onClick}
+                    to={links.dmt5}
+                />
+                <NavCard
+                    icon={() => <img src={Smarttrader} alt="Smarttrader" width="32" height="32" />}
+                    content={
+                        <Localize translate_text="Trade the world’s markets with our popular user-friendly platform." />
+                    }
+                    title={<Localize translate_text="SmartTrader" />}
+                    to={links.smarttrader}
+                    is_smarttrader_link
+                    external="true"
+                    target="_blank"
+                    onClick={onClick}
+                    otherLinkProps={{ rel: 'noopener noreferrer' }}
+                />
+            </Flex>
+            <MarginDivider width="2px" height="100%" color="grey-8" />
+            <Flex direction="column" wrap="wrap" jc="flex-start">
+                <StyledText>{localize('Trade types')}</StyledText>
+                <NavCard
+                    icon={() => <img src={Margin} alt="Margin" width="32" height="32" />}
+                    content={
+                        <Localize translate_text="Trade with leverage and low spreads for better returns on successful trades." />
+                    }
+                    title={<Localize translate_text="Margin trading" />}
+                    onClick={onClick}
+                    to={links.margin}
+                />
+
+                <NavCard
+                    icon={() => <img src={Options} alt="Options" width="32" height="32" />}
+                    content={
+                        <Localize translate_text="Earn fixed payouts by predicting an asset's price movement." />
+                    }
+                    title={<Localize translate_text="Options" />}
+                    onClick={onClick}
+                    to={links.options}
+                />
+                <NavCard
+                    icon={() => <img src={Multipliers} alt="Multipliers" width="32" height="32" />}
+                    content={
+                        <Localize translate_text="Combine the upside of margin trading with the simplicity of options." />
+                    }
+                    title={<Localize translate_text="Multipliers" />}
+                    onClick={onClick}
+                    to={links.multipliers}
+                />
+            </Flex>
         </Flex>
-    </Flex>
-)
+    )
+}
 
 NavPlatform.propTypes = {
     onClick: PropTypes.func,
+    setCurrentPage: PropTypes.func,
 }
 
-export const NavMarket = ({ onClick }) => (
-    <Flex direction="column" wrap="wrap" jc="flex-start">
-        <NavCard
-            icon={() => <img src={Forex} alt="Forex" width="32" height="32" />}
-            content={
-                <Localize translate_text="Trade the world’s largest financial market with popular forex pairs." />
-            }
-            title={<Localize translate_text="Forex" />}
-            onClick={onClick}
-            to="/markets#forex"
-        />
-        <NavCard
-            icon={() => (
-                <img src={SyntheticIndices} alt="SyntheticIndices" width="32" height="32" />
-            )}
-            content={
-                <Localize translate_text="Enjoy synthetic markets that emulate real-world market movements." />
-            }
-            title={<Localize translate_text="Synthetic indices" />}
-            onClick={onClick}
-            to="/markets#synthetic"
-        />
-        <NavCard
-            icon={() => <img src={StockIndices} alt="StockIndices" width="32" height="32" />}
-            content={
-                <Localize translate_text="Predict broader market trends and diversify your risk with stock indices." />
-            }
-            title={<Localize translate_text="Stock indices" />}
-            onClick={onClick}
-            to="/markets#stock"
-        />
-        <NavCard
-            icon={() => <img src={Commodities} alt="Commodities" width="32" height="32" />}
-            content={
-                <Localize translate_text="Trade natural resources that are central to the world's economy." />
-            }
-            title={<Localize translate_text="Commodities" />}
-            onClick={onClick}
-            to="/markets#commodities"
-        />
-    </Flex>
-)
+export const NavMarket = ({ onClick, setCurrentPage }) => {
+    const links = {
+        forex: '/markets#forex',
+        synthetic: '/markets#synthetic',
+        stock: '/markets#stock',
+        commodities: '/markets#commodities',
+    }
+
+    useEffect(() => {
+        if (Object.values(links).includes(window.location.pathname + window.location.hash))
+            setCurrentPage('markets')
+    }, [])
+
+    return (
+        <Flex direction="column" wrap="wrap" jc="flex-start">
+            <NavCard
+                icon={() => <img src={Forex} alt="Forex" width="32" height="32" />}
+                content={
+                    <Localize translate_text="Trade the world’s largest financial market with popular forex pairs." />
+                }
+                title={<Localize translate_text="Forex" />}
+                onClick={onClick}
+                to={links.forex}
+            />
+            <NavCard
+                icon={() => (
+                    <img src={SyntheticIndices} alt="SyntheticIndices" width="32" height="32" />
+                )}
+                content={
+                    <Localize translate_text="Enjoy synthetic markets that emulate real-world market movements." />
+                }
+                title={<Localize translate_text="Synthetic indices" />}
+                onClick={onClick}
+                to={links.synthetic}
+            />
+            <NavCard
+                icon={() => <img src={StockIndices} alt="StockIndices" width="32" height="32" />}
+                content={
+                    <Localize translate_text="Predict broader market trends and diversify your risk with stock indices." />
+                }
+                title={<Localize translate_text="Stock indices" />}
+                onClick={onClick}
+                to={links.stock}
+            />
+            <NavCard
+                icon={() => <img src={Commodities} alt="Commodities" width="32" height="32" />}
+                content={
+                    <Localize translate_text="Trade natural resources that are central to the world's economy." />
+                }
+                title={<Localize translate_text="Commodities" />}
+                onClick={onClick}
+                to={links.commodities}
+            />
+        </Flex>
+    )
+}
 
 NavMarket.propTypes = {
     onClick: PropTypes.func,
+    setCurrentPage: PropTypes.func,
 }
 
-export const NavCompany = ({ onClick }) => (
-    <Flex direction="column" wrap="wrap" jc="flex-start" max_width="42rem">
-        <CardLink
-            icon={() => <img src={Story} alt="story" width="24" height="24" />}
-            title={localize('Our story')}
-            onClick={onClick}
-            to="/about/#story"
-        />
-        <CardLink
-            icon={() => <img src={Leadership} alt="leadership" width="24" height="24" />}
-            title={localize('Our leadership')}
-            onClick={onClick}
-            to="/about/#leadership"
-        />
-        <CardLink
-            icon={() => <img src={RegulatoryInfo} alt="regulatory" width="24" height="24" />}
-            title={localize('Regulatory information')}
-            onClick={onClick}
-            to="/regulatory/"
-        />
-        <CardLink
-            icon={() => <img src={Choose} alt="choose" width="24" height="24" />}
-            title={localize('Why choose us?')}
-            onClick={onClick}
-            to="/why-choose-us/"
-        />
-        <CardLink
-            icon={() => <img src={Partner} alt="partner" width="24" height="24" />}
-            title={localize('Partnership programmes')}
-            onClick={onClick}
-            to="/partners/"
-        />
+export const NavCompany = ({ onClick, setCurrentPage }) => {
+    const links = {
+        story: '/about/#story',
+        leadership: '/about/#leadership',
+        regulatory: '/regulatory/',
+        choose: '/markets#commodities',
+        partners: '/partners/',
+        contact: '/contact-us/',
+        career: '/careers/',
+    }
 
-        <CardLink
-            icon={() => <img src={Contact} alt="contact" width="24" height="24" />}
-            title={localize('Contact us')}
-            onClick={onClick}
-            to="/contact-us/"
-        />
-        <CardLink
-            icon={() => <img src={Career} alt="career" width="24" height="24" />}
-            title={localize('Careers')}
-            onClick={onClick}
-            to="/careers/"
-            external="true"
-        />
-    </Flex>
-)
+    useEffect(() => {
+        if (Object.values(links).includes(window.location.pathname + window.location.hash))
+            setCurrentPage('company')
+    }, [])
+
+    return (
+        <Flex direction="column" wrap="wrap" jc="flex-start" max_width="42rem">
+            <CardLink
+                icon={() => <img src={Story} alt="story" width="24" height="24" />}
+                title={localize('Our story')}
+                onClick={onClick}
+                to={links.story}
+            />
+            <CardLink
+                icon={() => <img src={Leadership} alt="leadership" width="24" height="24" />}
+                title={localize('Our leadership')}
+                onClick={onClick}
+                to={links.leadership}
+            />
+            <CardLink
+                icon={() => <img src={RegulatoryInfo} alt="regulatory" width="24" height="24" />}
+                title={localize('Regulatory information')}
+                onClick={onClick}
+                to={links.regulatory}
+            />
+            <CardLink
+                icon={() => <img src={Choose} alt="choose" width="24" height="24" />}
+                title={localize('Why choose us?')}
+                onClick={onClick}
+                to={links.choose}
+            />
+            <CardLink
+                icon={() => <img src={Partner} alt="partner" width="24" height="24" />}
+                title={localize('Partnership programmes')}
+                onClick={onClick}
+                to={links.partners}
+            />
+            <CardLink
+                icon={() => <img src={Contact} alt="contact" width="24" height="24" />}
+                title={localize('Contact us')}
+                onClick={onClick}
+                to={links.contact}
+            />
+            <CardLink
+                icon={() => <img src={Career} alt="career" width="24" height="24" />}
+                title={localize('Careers')}
+                onClick={onClick}
+                to={links.career}
+                external="true"
+            />
+        </Flex>
+    )
+}
 
 NavCompany.propTypes = {
     onClick: PropTypes.func,
+    setCurrentPage: PropTypes.func,
 }
 
-export const NavResources = ({ onClick }) => (
-    <Flex direction="column" wrap="wrap" jc="flex-start" max_width="42rem">
-        <CardLink
-            icon={() => <img src={Help} alt="help" width="24" height="24" />}
-            title={localize('Help centre')}
-            onClick={onClick}
-            to="/help-centre/"
-        />
-        <CardLink
-            icon={() => <img src={Community} alt="community" width="24" height="24" />}
-            title={localize('Community')}
-            onClick={onClick}
-            to={community_url}
-            target="_blank"
-            external="true"
-            rel="noopener noreferrer"
-        />
-        <CardLink
-            icon={() => <img src={Payment} alt="payment" width="24" height="24" />}
-            title={localize('Payment methods')}
-            onClick={onClick}
-            to="/payment-methods/"
-        />
-        <CardLink
-            icon={() => <Signals dynamic_id="dmt5-signals" />}
-            title={localize('DMT5 Signals')}
-            onClick={onClick}
-            to="/dmt5-trading-signals/#signal-subscriber/"
-        />
-        {/* TODO: add this when blog is ready */}
-        {/* <CardLink title={localize('Blog')} to="/blog/" /> */}
-    </Flex>
-)
+export const NavResources = ({ onClick, setCurrentPage }) => {
+    const links = {
+        help: '/help-centre/',
+        payment: '/payment-methods/',
+        signals: '/dmt5-trading-signals/#signal-subscriber/',
+    }
+
+    useEffect(() => {
+        if (Object.values(links).includes(window.location.pathname + window.location.hash))
+            setCurrentPage('resources')
+    }, [])
+
+    return (
+        <Flex direction="column" wrap="wrap" jc="flex-start" max_width="42rem">
+            <CardLink
+                icon={() => <img src={Help} alt="help" width="24" height="24" />}
+                title={localize('Help centre')}
+                onClick={onClick}
+                to={links.help}
+            />
+            <CardLink
+                icon={() => <img src={Community} alt="community" width="24" height="24" />}
+                title={localize('Community')}
+                onClick={onClick}
+                to={community_url}
+                target="_blank"
+                external="true"
+                rel="noopener noreferrer"
+            />
+            <CardLink
+                icon={() => <img src={Payment} alt="payment" width="24" height="24" />}
+                title={localize('Payment methods')}
+                onClick={onClick}
+                to={links.payment}
+            />
+            <CardLink
+                icon={() => <Signals dynamic_id="dmt5-signals" />}
+                title={localize('DMT5 Signals')}
+                onClick={onClick}
+                to={links.signals}
+            />
+            {/* TODO: add this when blog is ready */}
+            {/* <CardLink title={localize('Blog')} to="/blog/" /> */}
+        </Flex>
+    )
+}
 
 NavResources.propTypes = {
     onClick: PropTypes.func,
+    setCurrentPage: PropTypes.func,
 }
 
 export default OtherPlatform

--- a/src/components/custom/other-platforms.js
+++ b/src/components/custom/other-platforms.js
@@ -392,7 +392,7 @@ export const NavCompany = ({ onClick, setCurrentPage }) => {
         story: '/about/#story',
         leadership: '/about/#leadership',
         regulatory: '/regulatory/',
-        choose: '/markets#commodities',
+        choose: '/why-choose-us/',
         partners: '/partners/',
         contact: '/contact-us/',
         career: '/careers/',

--- a/src/components/custom/other-platforms.js
+++ b/src/components/custom/other-platforms.js
@@ -336,7 +336,7 @@ export const NavMarket = ({ onClick, setCurrentPage }) => {
     useEffect(() => {
         if (Object.values(links).includes(window.location.pathname + window.location.hash))
             setCurrentPage('markets')
-    }, [])
+    }, [window.location.hash])
 
     return (
         <Flex direction="column" wrap="wrap" jc="flex-start">
@@ -401,7 +401,7 @@ export const NavCompany = ({ onClick, setCurrentPage }) => {
     useEffect(() => {
         if (Object.values(links).includes(window.location.pathname + window.location.hash))
             setCurrentPage('company')
-    }, [])
+    }, [window.location.hash])
 
     return (
         <Flex direction="column" wrap="wrap" jc="flex-start" max_width="42rem">

--- a/src/components/custom/other-platforms.js
+++ b/src/components/custom/other-platforms.js
@@ -250,7 +250,7 @@ export const NavPlatform = ({ onClick, setCurrentPage }) => {
                     }
                     title={<Localize translate_text="DTrader" />}
                     onClick={onClick}
-                    to={links.dbot}
+                    to={links.dtrader}
                 />
                 <NavCard
                     icon={() => <img src={DBot} alt="DBot" width="32" height="32" />}

--- a/src/components/custom/other-platforms.js
+++ b/src/components/custom/other-platforms.js
@@ -336,7 +336,7 @@ export const NavMarket = ({ onClick, setCurrentPage }) => {
     useEffect(() => {
         if (Object.values(links).includes(window.location.pathname + window.location.hash))
             setCurrentPage('markets')
-    }, [window.location.hash])
+    }, [window?.location.hash])
 
     return (
         <Flex direction="column" wrap="wrap" jc="flex-start">
@@ -401,7 +401,7 @@ export const NavCompany = ({ onClick, setCurrentPage }) => {
     useEffect(() => {
         if (Object.values(links).includes(window.location.pathname + window.location.hash))
             setCurrentPage('company')
-    }, [window.location.hash])
+    }, [window?.location.hash])
 
     return (
         <Flex direction="column" wrap="wrap" jc="flex-start" max_width="42rem">

--- a/src/components/custom/platforms-dropdown.js
+++ b/src/components/custom/platforms-dropdown.js
@@ -63,7 +63,7 @@ const StyledContainer = styled(Container)`
     }
 `
 
-const PlatformsDropdown = ({ is_open, has_animation, Content, forward_ref, link_ref }) => {
+const PlatformsDropdown = ({ Content, forward_ref, has_animation, is_open, link_ref }) => {
     const [left, setLeft] = React.useState(0)
     const [left_arrow, setLeftArrow] = React.useState(0)
     const updateOffsets = () => {

--- a/src/components/layout/nav.js
+++ b/src/components/layout/nav.js
@@ -2,24 +2,24 @@
 import React, { useState, useEffect, useRef } from 'react'
 import { graphql, useStaticQuery } from 'gatsby'
 import PropTypes from 'prop-types'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 import PlatformsDropdown from '../custom/platforms-dropdown'
 import {
-    NavPlatform,
     NavCompany,
-    NavResources,
     NavMarket,
+    NavPlatform,
+    NavResources,
 } from 'components/custom/other-platforms.js'
 import { useOutsideClick } from 'components/hooks/outside-click'
 import { LocalizedLink, localize, LanguageSwitcher } from 'components/localization'
 import { Button, LinkButton } from 'components/form'
 import { Container, Show, Flex } from 'components/containers'
 import {
+    moveOffCanvasMenu,
     OffCanvasMenu,
     OffCanvasMenuPartner,
-    moveOffCanvasMenu,
-    Text,
     QueryImage,
+    Text,
 } from 'components/elements'
 import { SharedLinkStyle } from 'components/localization/localized-link'
 import Login from 'common/login'
@@ -110,7 +110,7 @@ export const Wrapper = styled(Container)`
     justify-content: space-between;
     height: 7.2rem;
     @media ${device.laptopL} {
-        width: ${({ width }) => width ?? "90%"};
+        width: ${({ width }) => width ?? '90%'};
     }
     @media ${device.laptop} {
         font-size: var(--text-size-xxs);
@@ -227,6 +227,13 @@ const StyledButton = styled.span`
     cursor: pointer;
     user-select: none;
     white-space: nowrap;
+    ${(props) =>
+        props.is_current_page &&
+        css`
+            &::before {
+                width: 1.6rem;
+            }
+        `}
 `
 
 const SignupButton = styled(Button)`
@@ -275,7 +282,7 @@ const LoginButton = styled(Button)`
 const MobileLogin = styled(Button)`
     display: none;
     font-size: 14px;
-    margin-left: ${({ margin_left }) => margin_left ?? "1.6rem" };
+    margin-left: ${({ margin_left }) => margin_left ?? '1.6rem'};
     @media ${device.tabletL} {
         display: block;
     }
@@ -363,6 +370,8 @@ const NavDesktop = ({ base }) => {
     const [show_button, showButton, hideButton] = moveButton()
     const [mounted, setMounted] = useState(false)
     const [has_scrolled, setHasScrolled] = useState(false)
+    const [current_page, set_current_page] = useState('')
+
     // trade
     const trade_ref = useRef(null)
     const link_trade_ref = useRef(null)
@@ -434,7 +443,9 @@ const NavDesktop = ({ base }) => {
                 link_ref={link_trade_ref}
                 is_open={is_trade_open}
                 has_animation={has_trade_animation}
-                Content={() => <NavPlatform onClick={handleTradeClick} />}
+                Content={() => (
+                    <NavPlatform onClick={handleTradeClick} setCurrentPage={set_current_page} />
+                )}
                 title={localize('Trading platforms')}
                 description={localize(
                     'Be in full control of your trading with our new and improved platforms.',
@@ -445,7 +456,9 @@ const NavDesktop = ({ base }) => {
                 link_ref={link_market_ref}
                 is_open={is_market_open}
                 has_animation={has_market_animation}
-                Content={() => <NavMarket onClick={handleMarketClick} />}
+                Content={() => (
+                    <NavMarket onClick={handleMarketClick} setCurrentPage={set_current_page} />
+                )}
                 title={localize('Markets')}
                 description={localize(
                     'Enjoy our wide range of assets on financial and synthetic markets.',
@@ -456,7 +469,9 @@ const NavDesktop = ({ base }) => {
                 link_ref={link_company_ref}
                 is_open={is_company_open}
                 has_animation={has_company_animation}
-                Content={() => <NavCompany onClick={handleCompanyClick} />}
+                Content={() => (
+                    <NavCompany onClick={handleCompanyClick} setCurrentPage={set_current_page} />
+                )}
                 title={localize('About us')}
                 description={localize(
                     "Get to know our leadership team, learn about our history, and see why we're different.",
@@ -467,7 +482,12 @@ const NavDesktop = ({ base }) => {
                 link_ref={link_resources_ref}
                 is_open={is_resources_open}
                 has_animation={has_resources_animation}
-                Content={() => <NavResources onClick={handleResourcesClick} />}
+                Content={() => (
+                    <NavResources
+                        onClick={handleResourcesClick}
+                        setCurrentPage={set_current_page}
+                    />
+                )}
                 title={localize('Resources')}
                 description={localize(
                     'Help yourself to various resources that can help you get the best out of your trading experience.',
@@ -493,6 +513,7 @@ const NavDesktop = ({ base }) => {
                         <StyledButton
                             aria-label={localize('Trade')}
                             active={is_trade_open}
+                            is_current_page={current_page === 'trade'}
                             ref={link_trade_ref}
                         >
                             {localize('Trade')}
@@ -502,6 +523,7 @@ const NavDesktop = ({ base }) => {
                         <StyledButton
                             aria-label={localize('Markets')}
                             active={is_market_open}
+                            is_current_page={current_page === 'markets'}
                             ref={link_market_ref}
                         >
                             {localize('Markets')}
@@ -511,6 +533,7 @@ const NavDesktop = ({ base }) => {
                         <StyledButton
                             aria-label={localize('About us')}
                             active={is_company_open}
+                            is_current_page={current_page === 'company'}
                             ref={link_company_ref}
                         >
                             {localize('About us')}
@@ -520,6 +543,7 @@ const NavDesktop = ({ base }) => {
                         <StyledButton
                             aria-label={localize('Resources')}
                             active={is_resources_open}
+                            is_current_page={current_page === 'resources'}
                             ref={link_resources_ref}
                         >
                             {localize('Resources')}


### PR DESCRIPTION
# Description
Summary
- Main navigation bar now shows current parent page by displaying a red underline under the link

Changes:
- Moved all card links to an array
- If current page matches a link in the array, return a string containing current navigation dropdown name
- Check links for the current page string. If match, sets the `is_current_page` to true which will activate the red underline.

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
