### PR TITLE
Yashim/fix: getLanguage() returning invalid language codes

### DIFF
--- a/src/common/utility.js
+++ b/src/common/utility.js
@@ -62,7 +62,8 @@ const checkElemInArray = (tab_list, tab) => tab_list.includes(tab)
 
 const getWindowWidth = () => (isBrowser() && window.screen ? window.screen.width : '')
 
-const getLanguage = () => (isBrowser() ? localStorage.getItem('i18n') || navigator.language : null)
+const getLanguage = () =>
+    isBrowser() ? localStorage.getItem('i18n')?.replace('-', '_') || navigator.language : null
 
 const getCrowdin = () =>
     isBrowser() ? localStorage.getItem('jipt_language_code_deriv-com') || navigator.language : null

--- a/src/common/utility.js
+++ b/src/common/utility.js
@@ -62,8 +62,7 @@ const checkElemInArray = (tab_list, tab) => tab_list.includes(tab)
 
 const getWindowWidth = () => (isBrowser() && window.screen ? window.screen.width : '')
 
-const getLanguage = () =>
-    isBrowser() ? localStorage.getItem('i18n')?.replace('-', '_') || navigator.language : null
+const getLanguage = () => (isBrowser() ? localStorage.getItem('i18n') || navigator.language : null)
 
 const getCrowdin = () =>
     isBrowser() ? localStorage.getItem('jipt_language_code_deriv-com') || navigator.language : null

--- a/src/common/websocket/socket_base.js
+++ b/src/common/websocket/socket_base.js
@@ -9,7 +9,7 @@ import { getAppId, getSocketURL } from './config'
 const BinarySocketBase = (() => {
     const init = () => {
         const socket_url = `${getSocketURL()}?app_id=${getAppId()}&l=${
-            getLanguage() === 'ach' ? getCrowdin() : getLanguage()
+            getLanguage() === 'ach' ? getCrowdin() : getLanguage()?.replace('-', '_')
         }&brand=${brand_name.toLowerCase()}`
 
         return new WebSocket(socket_url)


### PR DESCRIPTION
Co-authored-by: Yashim Wong <yashimwong@gmail.com>

Summary
- getLanguage() was returning wrong language codes (kebab-case) 

Changes:

-   ...

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
