### PR TITLE
Abdalla/Add: LoggedIn and language to GTMData

### DIFF
--- a/src/common/utility.js
+++ b/src/common/utility.js
@@ -1,5 +1,5 @@
-import extend from 'extend'
 import Cookies from 'js-cookie'
+import extend from 'extend'
 
 const toISOFormat = (date) => {
     if (date instanceof Date) {

--- a/src/common/utility.js
+++ b/src/common/utility.js
@@ -1,4 +1,5 @@
 import extend from 'extend'
+import Cookies from 'js-cookie'
 
 const toISOFormat = (date) => {
     if (date instanceof Date) {
@@ -66,6 +67,8 @@ const getLanguage = () => (isBrowser() ? localStorage.getItem('i18n') || navigat
 
 const getCrowdin = () =>
     isBrowser() ? localStorage.getItem('jipt_language_code_deriv-com') || navigator.language : null
+
+const getClientInformation = (domain) => Cookies.get('client_information', { domain })
 
 class PromiseClass {
     constructor() {
@@ -140,6 +143,11 @@ const dp2p_google_play_url =
 const cfd_warning_height_desktop = 8
 const cfd_warning_height_tablet = 12
 
+const getDomain = () =>
+    isBrowser() && window.location.hostname.includes(deriv_cookie_domain)
+        ? deriv_cookie_domain
+        : 'binary.sx'
+
 export {
     affiliate_signin_url,
     affiliate_signup_url,
@@ -172,6 +180,8 @@ export {
     isBrowser,
     getCrowdin,
     getCryptoDecimals,
+    getClientInformation,
+    getDomain,
     getPropertyValue,
     getLanguage,
     getLocationHash,

--- a/src/components/hooks/gtm-data-hooks.js
+++ b/src/components/hooks/gtm-data-hooks.js
@@ -6,16 +6,19 @@ const useGTMData = () => {
     const domain = getDomain()
     const client_information = getClientInformation(domain)
     const has_dataLayer = isBrowser() && window.dataLayer
+    const is_logged_in = !!client_information
 
     useEffect(() => {
         if (gtm_data) {
             has_dataLayer &&
                 window.dataLayer.push({
                     ...gtm_data,
-                    loggedIn: !!client_information,
+                    loggedIn: is_logged_in,
                     language: getLanguage(),
-                    visitorId: client_information?.loginid,
-                    currency: client_information?.currency,
+                    ...(is_logged_in && {
+                        visitorId: client_information.loginid,
+                        currency: client_information.currency,
+                    }),
                 })
         }
     }, [gtm_data])

--- a/src/components/hooks/gtm-data-hooks.js
+++ b/src/components/hooks/gtm-data-hooks.js
@@ -4,7 +4,7 @@ import { getClientInformation, getDomain, getLanguage, isBrowser } from 'common/
 const useGTMData = () => {
     const [gtm_data, setGTMData] = React.useState(null)
     const domain = getDomain()
-    const is_logged_in = getClientInformation(domain)
+    const client_information = getClientInformation(domain)
     const has_dataLayer = isBrowser() && window.dataLayer
 
     useEffect(() => {
@@ -12,8 +12,10 @@ const useGTMData = () => {
             has_dataLayer &&
                 window.dataLayer.push({
                     ...gtm_data,
-                    loggedIn: is_logged_in,
+                    loggedIn: !!client_information,
                     language: getLanguage(),
+                    visitorId: client_information?.loginid,
+                    currency: client_information?.currency,
                 })
         }
     }, [gtm_data])

--- a/src/components/hooks/gtm-data-hooks.js
+++ b/src/components/hooks/gtm-data-hooks.js
@@ -1,0 +1,17 @@
+import React, { useEffect } from 'react'
+import { isBrowser } from 'common/utility'
+
+const useGTMData = () => {
+    const [gtm_data, setGTMData] = React.useState(null)
+    const has_dataLayer = isBrowser() && window.dataLayer
+
+    useEffect(() => {
+        if (gtm_data) {
+            has_dataLayer && window.dataLayer.push(gtm_data)
+        }
+    }, [gtm_data])
+
+    return [gtm_data, setGTMData]
+}
+
+export default useGTMData

--- a/src/components/hooks/gtm-data-hooks.js
+++ b/src/components/hooks/gtm-data-hooks.js
@@ -1,13 +1,20 @@
 import React, { useEffect } from 'react'
-import { isBrowser } from 'common/utility'
+import { getClientInformation, getDomain, getLanguage, isBrowser } from 'common/utility'
 
 const useGTMData = () => {
     const [gtm_data, setGTMData] = React.useState(null)
+    const domain = getDomain()
+    const is_logged_in = getClientInformation(domain)
     const has_dataLayer = isBrowser() && window.dataLayer
 
     useEffect(() => {
         if (gtm_data) {
-            has_dataLayer && window.dataLayer.push(gtm_data)
+            has_dataLayer &&
+                window.dataLayer.push({
+                    ...gtm_data,
+                    loggedIn: is_logged_in,
+                    language: getLanguage(),
+                })
         }
     }, [gtm_data])
 

--- a/src/components/hooks/use-livechat.js
+++ b/src/components/hooks/use-livechat.js
@@ -1,6 +1,11 @@
 import React from 'react'
-import Cookies from 'js-cookie'
-import { isBrowser, livechat_client_id, livechat_license_id } from 'common/utility'
+import {
+    getClientInformation,
+    getDomain,
+    isBrowser,
+    livechat_client_id,
+    livechat_license_id,
+} from 'common/utility'
 
 export const useLivechat = () => {
     const [is_livechat_interactive, setLiveChatInteractive] = React.useState(false)
@@ -26,9 +31,7 @@ export const useLivechat = () => {
         let cookie_interval = null
         let script_timeout = null
         if (isBrowser()) {
-            const domain = window.location.hostname.includes('deriv.com')
-                ? 'deriv.com'
-                : 'binary.sx'
+            const domain = getDomain()
             try {
                 import('@livechat/customer-sdk').then((CSDK) => {
                     CustomerSdk.current = CSDK
@@ -43,9 +46,7 @@ export const useLivechat = () => {
                 return function () {
                     const currentCookie = document.cookie
                     if (currentCookie != lastCookie) {
-                        const client_information = Cookies.get('client_information', {
-                            domain,
-                        })
+                        const client_information = getClientInformation(domain)
                         setLoggedIn(!!client_information)
                         lastCookie = currentCookie // store latest cookie
                     }
@@ -76,9 +77,7 @@ export const useLivechat = () => {
     React.useEffect(() => {
         if (isBrowser()) {
             let customerSDK = null
-            const domain = window.location.hostname.includes('deriv.com')
-                ? 'deriv.com'
-                : 'binary.sx'
+            const domain = getDomain()
             if (CustomerSdk.current) {
                 try {
                     customerSDK = CustomerSdk.current.init({
@@ -93,9 +92,7 @@ export const useLivechat = () => {
             if (is_livechat_interactive) {
                 window.LiveChatWidget.on('ready', () => {
                     if (is_logged_in) {
-                        const client_information = Cookies.get('client_information', {
-                            domain,
-                        })
+                        const client_information = getClientInformation(domain)
                         const {
                             loginid,
                             email,

--- a/src/components/layout/layout.js
+++ b/src/components/layout/layout.js
@@ -11,7 +11,7 @@ import { LocationProvider } from './location-context'
 import EURedirect, { useModal } from 'components/custom/_eu-redirect-modal.js'
 import CookieBanner from 'components/custom/cookie-banner'
 import { CookieStorage } from 'common/storage'
-import { getClientInformation, getDomain, getLanguage, isBrowser } from 'common/utility'
+import { isBrowser } from 'common/utility'
 import { DerivStore } from 'store'
 import { Localize } from 'components/localization'
 import { Text } from 'components/elements'
@@ -98,7 +98,6 @@ const Layout = ({
     const [gtm_data, setGTMData] = useGTMData()
 
     const is_static = type === 'static'
-    const is_logged_in = getClientInformation(getDomain())
 
     const Main = styled.main`
         margin-top: ${(props) =>
@@ -135,11 +134,7 @@ const Layout = ({
                 (!is_eu_country || tracking_status === 'accepted') && !gtm_data && has_dataLayer
 
             if (allow_tracking) {
-                setGTMData({
-                    event: 'allow_tracking',
-                    loggedIn: is_logged_in,
-                    language: getLanguage(),
-                })
+                setGTMData({ event: 'allow_tracking' })
             }
             setMounted(true)
         }
@@ -148,8 +143,7 @@ const Layout = ({
     const onAccept = () => {
         tracking_status_cookie.set(TRACKING_STATUS_KEY, 'accepted')
 
-        if (!gtm_data && has_dataLayer)
-            setGTMData({ event: 'allow_tracking', loggedIn: is_logged_in, language: getLanguage() })
+        if (!gtm_data && has_dataLayer) setGTMData({ event: 'allow_tracking' })
 
         setShowCookieBanner(false)
     }

--- a/src/components/layout/layout.js
+++ b/src/components/layout/layout.js
@@ -137,7 +137,7 @@ const Layout = ({
             if (allow_tracking) {
                 setGTMData({
                     event: 'allow_tracking',
-                    LoggedIn: is_logged_in,
+                    loggedIn: is_logged_in,
                     language: getLanguage(),
                 })
             }
@@ -149,7 +149,7 @@ const Layout = ({
         tracking_status_cookie.set(TRACKING_STATUS_KEY, 'accepted')
 
         if (!gtm_data && has_dataLayer)
-            setGTMData({ event: 'allow_tracking', LoggedIn: is_logged_in, language: getLanguage() })
+            setGTMData({ event: 'allow_tracking', loggedIn: is_logged_in, language: getLanguage() })
 
         setShowCookieBanner(false)
     }


### PR DESCRIPTION
# Description
We need to sent `loggedIn` and `language` properties along with `event` on every event triggered.
This PR
* Created new hooks that sent out `gtm_data` and `setGTMData`
* `gtm_data` contains an object that is currently of shape `{ event: eventName }`
* Final object to sent out `{ event: eventName, loggedIn: is_logged_in, language: language }`
* Note: `eventName: string` - `loggedIn: boolean` - `language: string`

## Type of change

-   [ ] Bug fix
-   [x] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
