### PR TITLE
amam/change_to_href

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -122,15 +122,18 @@ export const onRouteUpdate = ({ location }) => {
     checkDomain()
 
     const is_contact_us = /contact-us/g.test(location.pathname)
-    const has_refreshed = Cookies.get('has_refreshed')
+    const has_refreshed = Cookies.get('had_refreshed')
 
     if (!has_refreshed && is_contact_us) {
-        Cookies.set('has_refreshed', '1')
-        window.location.reload(true)
+        Cookies.set('had_refreshed', '1')
+        // location.reload wont work on chrome
+        // eslint-disable-next-line no-self-assign
+        window.location.href = window.location.href
     }
 }
 
 // trigger an immediate page refresh when an update is found
-export const onServiceWorkerUpdateReady = () => window.location.reload(true)
+// eslint-disable-next-line no-self-assign
+export const onServiceWorkerUpdateReady = () => (window.location.href = window.location.href)
 
 export const wrapPageElement = WrapPagesWithLocaleContext


### PR DESCRIPTION
# Description
location.reload won't work on chrome, change it to href

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
