### PR TITLE
amam/improve caching strategy

### DIFF
--- a/deriv.com.conf
+++ b/deriv.com.conf
@@ -9,6 +9,10 @@ server {
 
     error_page 404 /404.html;
 
+    location = /sw.js {
+        add_header Cache-Control "public, max-age=0, must-revalidate";
+    }
+
     location @custom_error_503 {
         return 503;
     }
@@ -22,10 +26,6 @@ server {
     }
 
     location /page-data {
-        add_header Cache-Control "public, max-age=0, must-revalidate";
-    }
-
-    location = /sw.js {
         add_header Cache-Control "public, max-age=0, must-revalidate";
     }
 

--- a/deriv.com.conf
+++ b/deriv.com.conf
@@ -1,39 +1,10 @@
-#map $http_cf_ipcountry $redirected_url {	
-# BE /eu;	
-# BG /eu;	
-# CZ /eu;	
-# DK /eu;	
-# DE /eu;	
-# EE /eu;	
-# IE /eu;	
-# EL /eu;	
-# ES /eu;	
-# FR /eu;	
-# HR /eu;	
-# IT /eu;	
-# CY /eu;	
-# LV /eu;	
-# LT /eu;	
-# LU /eu;	
-# HU /eu;	
-# MT /eu;	
-# NL /eu;	
-# AT /eu;	
-# PL /eu;	
-# PT /eu;	
-# RO /eu;	
-# SI /eu;	
-# SK /eu;	
-# FI /eu;	
-# SE /eu;	
-#}
-
 server {
     listen 80;
-    server_name  _;
+    server_name _;
+    root /usr/share/nginx/html;
 
-    add_header Cache-Control "public, max-age=7200, s-maxage=600, must-revalidate";
     add_header X-CF-IPCOUNTRY $http_cf_ipcountry;
+    index index.html index.htm;
     charset UTF-8;
 
     error_page 404 /404.html;
@@ -46,11 +17,23 @@ server {
         return 404;
     }
 
-    location / {
-        #if ($http_cf_ipcountry) {
-        #    rewrite ^/(.*)$ $scheme://$host$redirected_url/$1 permanent;	
-        #}
-        root   /usr/share/nginx/html;
-        index  index.html index.htm;
+    location ~* \.(?:html)$ {
+        add_header Cache-Control "public, max-age=0, must-revalidate";
+    }
+
+    location /page-data {
+        add_header Cache-Control "public, max-age=0, must-revalidate";
+    }
+
+    location = /sw.js {
+        add_header Cache-Control "public, max-age=0, must-revalidate";
+    }
+
+    location /static {
+        add_header Cache-Control "public, max-age=31536000, immutable";
+    }
+
+    location ~* \.(?:js|css)$ {
+        add_header Cache-Control "public, max-age=31536000, immutable";
     }
 }

--- a/src/components/containers/seo.js
+++ b/src/components/containers/seo.js
@@ -54,7 +54,7 @@ const SEO = ({ description, meta, title, no_index, has_organization_schema }) =>
             '@context': 'https://schema.org',
             '@type': 'Organization',
             name: 'Deriv',
-            alternateName: 'Binary.com',
+            alternateName: 'Deriv.com',
             url: 'http://www.deriv.com',
             logo: 'https://deriv.com/static/1b57a116945933314eefeec0030c8e9d/2a4de/logo.png',
             sameAs: [
@@ -63,7 +63,7 @@ const SEO = ({ description, meta, title, no_index, has_organization_schema }) =>
                 'https://www.instagram.com/deriv_official',
                 'https://youtube.com/c/Derivdotcom',
                 'https://www.linkedin.com/company/derivdotcom/',
-                'http://www.deriv.com',
+                'https://www.deriv.com',
             ],
         }
     }
@@ -148,11 +148,11 @@ const SEO = ({ description, meta, title, no_index, has_organization_schema }) =>
                 },
                 ...(no_index || no_index_staging || is_ach_page
                     ? [
-                        {
-                            name: 'robots',
-                            content: 'noindex',
-                        },
-                    ]
+                          {
+                              name: 'robots',
+                              content: 'noindex',
+                          },
+                      ]
                     : []),
             ].concat(meta)}
         >


### PR DESCRIPTION
We should register a correct caching strategy https://www.gatsbyjs.com/docs/caching/ . we supposed to not cache (max-age: 0) for resources that always need to be invalidated (html, page data, service worker file). and only cache resources that is cacheable (static, css, logic js)

## Type of change

-   [ ] Bug fix
-   [x] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
