### PR TITLE
Fix:Issue on navbar went missing on 992px width

### DIFF
--- a/src/components/layout/nav.js
+++ b/src/components/layout/nav.js
@@ -134,7 +134,7 @@ export const NavLeft = styled.div`
     max-width: 30rem;
     width: 100%;
 
-    @media ${device.tabletL} {
+    @media (max-width: 991px) {
         display: none;
     }
 `
@@ -164,7 +164,7 @@ const NavCenter = styled.ul`
     @media (max-width: 1105px) {
         font-size: 11px;
     }
-    @media ${device.tabletL} {
+    @media (max-width: 991px) {
         display: none;
     }
 `
@@ -208,7 +208,7 @@ const NavRight = styled.div`
         pointer-events: ${(props) => (props.move ? 'visible' : 'none')};
         cursor: ${(props) => (props.move ? 'pointer' : 'default')};
     }
-    @media ${device.tabletL} {
+    @media (max-width: 991px) {
         display: none;
     }
 `


### PR DESCRIPTION
Changes:

-   Change device sizing from 992px to 991px for desktop nav component (NavLeft,NavCenter and NavRight)

## Type of change

-   [X] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
