### PR TITLE
yashim/perf: image serving optimisation

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -29,7 +29,6 @@ module.exports = {
                 useMozJpeg: process.env.GATSBY_JPEG_ENCODER === `MOZJPEG`,
                 stripMetadata: true,
                 defaultQuality: 50,
-                webpQuality: 50,
             },
         },
         {

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -29,6 +29,7 @@ module.exports = {
                 useMozJpeg: process.env.GATSBY_JPEG_ENCODER === `MOZJPEG`,
                 stripMetadata: true,
                 defaultQuality: 50,
+                webpQuality: 50,
             },
         },
         {

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -20,7 +20,17 @@ module.exports = {
             },
         },
         'gatsby-transformer-sharp',
-        'gatsby-plugin-sharp',
+        {
+            resolve: `gatsby-plugin-sharp`,
+            options: {
+                failOnError: true,
+                base64Width: 20,
+                forceBase64Format: `webp`,
+                useMozJpeg: process.env.GATSBY_JPEG_ENCODER === `MOZJPEG`,
+                stripMetadata: true,
+                defaultQuality: 50,
+            },
+        },
         {
             resolve: 'gatsby-plugin-sitemap',
             options: {
@@ -156,7 +166,7 @@ module.exports = {
                 stages: ['develop'],
                 extensions: ['js'],
                 exclude: ['node_modules', '.cache', 'public'],
-              },
+            },
         },
         {
             resolve: 'gatsby-plugin-stylelint',

--- a/src/components/elements/query-image.js
+++ b/src/components/elements/query-image.js
@@ -16,19 +16,13 @@ export const ImageWrapper = styled.div`
 
 const QueryImage = ({ data, alt, width, height, className }) => {
     if (data) {
-        const data_fluid = data.childImageSharp.fluid
-        const data_fixed = data.childImageSharp.fixed
+        const { fluid, fixed } = data.childImageSharp
         return (
             <ImageWrapper width={width} height={height} className={className}>
-                <Img
-                    alt={alt}
-                    {...(data_fluid ? { fluid: data_fluid } : { fixed: data_fixed })}
-                    height="100%"
-                />
+                <Img alt={alt} {...(fluid ? { fluid } : { fixed })} height="100%" />
             </ImageWrapper>
         )
     }
-
     return null
 }
 

--- a/src/components/graphql/fragments.js
+++ b/src/components/graphql/fragments.js
@@ -3,7 +3,7 @@ import { graphql } from 'gatsby'
 export const backGroundBlur = graphql`
     fragment backGroundBlur on File {
         childImageSharp {
-            fluid(quality: 90, maxWidth: 2048, srcSetBreakpoints: [600, 1440]) {
+            fluid(quality: 80, maxWidth: 2048) {
                 ...GatsbyImageSharpFluid_withWebp_noBase64
                 originalName
             }
@@ -14,7 +14,7 @@ export const backGroundBlur = graphql`
 export const fadeIn = graphql`
     fragment fadeIn on File {
         childImageSharp {
-            fluid(maxWidth: 1024, srcSetBreakpoints: [600, 1440]) {
+            fluid(maxWidth: 1024) {
                 ...GatsbyImageSharpFluid_withWebp_noBase64
                 originalName
             }

--- a/src/components/layout/livechat.js
+++ b/src/components/layout/livechat.js
@@ -39,9 +39,9 @@ const LiveChat = () => {
                     onMouseLeave={() => setLivechatHover(false)}
                 >
                     {is_livechat_hover ? (
-                        <img src={LiveChatHover} alt="livechat hover" />
+                        <img src={LiveChatHover} width="32" height="32" alt="livechat hover" />
                     ) : (
-                        <img src={LiveChatIC} alt="livechat ic" />
+                        <img src={LiveChatIC} width="32" height="32" alt="livechat ic" />
                     )}
                 </StyledLiveChat>
             )}

--- a/src/components/layout/nav.js
+++ b/src/components/layout/nav.js
@@ -359,15 +359,21 @@ const NavMobile = ({ is_ppc, is_ppc_redirect, is_logged_in }) => {
                     alt="hamburger"
                     onClick={openOffCanvasMenu}
                     width="16px"
+                    height="14px"
                 />
             )}
 
             <LogoLinkMobile to="/" aria-label={localize('Home')}>
                 <Flex>
-                    <img src={LogoOnly} alt="logo only" width="115px" />
+                    <img src={LogoOnly} alt="logo only" width="115px" height="20px" />
                     <LogoDescription ai="center">
                         <Line />
-                        <img src={LogoCombinedShape} alt="logo combined shape 2" />
+                        <img
+                            src={LogoCombinedShape}
+                            alt="logo combined shape 2"
+                            width="120"
+                            height="17"
+                        />
                     </LogoDescription>
                 </Flex>
             </LogoLinkMobile>
@@ -535,7 +541,12 @@ const NavDesktop = ({ base, is_ppc, is_ppc_redirect, is_logged_in }) => {
                         />
                     </LogoLink>
                     <Line />
-                    <img src={LogoCombinedShape} alt="logo combined shape" />
+                    <img
+                        src={LogoCombinedShape}
+                        alt="logo combined shape"
+                        width="120"
+                        height="17"
+                    />
                 </NavLeft>
                 <NavCenter>
                     <NavLink onClick={handleTradeClick}>

--- a/src/pages/home/_what-our-clients-say.js
+++ b/src/pages/home/_what-our-clients-say.js
@@ -1,19 +1,11 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
-import { Carousel, Header, Text, Divider } from 'components/elements'
+import { graphql, useStaticQuery } from 'gatsby'
+import { Carousel, Divider, Header, QueryImage, Text } from 'components/elements'
 import { localize, Localize } from 'components/localization'
 import device from 'themes/device'
 import { Container, SectionContainer, Flex } from 'components/containers'
-import FabioImage from 'images/common/fabio.png'
-import FernandoImage from 'images/common/fernando.png'
-import JoseImage from 'images/common/jose.png'
-import ManikandanImage from 'images/common/manikandan.png'
-import MustafijurImage from 'images/common/mustafijur.png'
-import MugendaImage from 'images/common/paul-mugenda.png'
-import VilcaImage from 'images/common/paul-vilca.png'
-import TueloImage from 'images/common/tuelo.png'
-import VipulImage from 'images/common/vipul.png'
 
 const StyledSection = styled(SectionContainer)`
     @media ${device.tabletL} {
@@ -80,7 +72,7 @@ const ImageWrapper = styled.div`
     }
 `
 
-const ClientSlide = ({ quote, img_path, img_alt, name, location }) => (
+const ClientSlide = ({ quote, img, img_alt, name, location }) => (
     <Flex ai="center" height="unset">
         <ClientCard>
             <QuoteText as="blockquote">{quote}</QuoteText>
@@ -88,7 +80,7 @@ const ClientSlide = ({ quote, img_path, img_alt, name, location }) => (
             <Flex p="1.7rem 0 0 0">
                 <Flex ai="center" width="auto">
                     <ImageWrapper>
-                        <img src={img_path} alt={img_alt} width="50" height="50" loading="lazy" />
+                        <QueryImage data={img} width="50" height="50" alt={img_alt} />
                     </ImageWrapper>
                 </Flex>
                 <figure>
@@ -101,116 +93,122 @@ const ClientSlide = ({ quote, img_path, img_alt, name, location }) => (
 )
 
 ClientSlide.propTypes = {
+    img: PropTypes.object,
     img_alt: PropTypes.string,
-    img_path: PropTypes.string,
     location: PropTypes.node,
     name: PropTypes.string,
     quote: PropTypes.node,
 }
 
-const fabio = {
-    name: 'Fábio Oliveira',
-    location: <Localize translate_text="Kenya" />,
-    img_path: FabioImage,
-    quote: (
-        <Localize translate_text="It surpassed my expectations. Binary got it right with Deriv. Trading on the platform is excellent and it allows for making accurate graphical analyses of the market and adding support and resistance markings with the use of horizontal lines, RSI, FIBO and much more." />
-    ),
-    index: 1,
-}
-
-const mugenda = {
-    name: 'Paul Mugenda',
-    location: <Localize translate_text="Kenya" />,
-    img_path: MugendaImage,
-    quote: (
-        <Localize translate_text="The Deriv platform is fast, easy to navigate, and very user-friendly. It looks great and it’s packed with many appealing features. Deposits and withdrawals are easy. My favourite markets to trade on are the Crash and Boom indices on MT5." />
-    ),
-    index: 2,
-}
-
-const tuelo = {
-    name: 'Tuelo Ronald Boitshwarelo',
-    location: <Localize translate_text="Botswana" />,
-    img_path: TueloImage,
-    quote: (
-        <Localize translate_text="What I like most is that my withdrawals are processed fast. This is the platform of the future: it offers more functionality as well as different ways to trade. No other broker has given me the same satisfaction as Deriv has. A great broker indeed." />
-    ),
-    index: 3,
-}
-
-const mustafijur = {
-    name: 'Mustafijur Rahman',
-    location: <Localize translate_text="Bangladesh" />,
-    img_path: MustafijurImage,
-    quote: (
-        <Localize translate_text="The Deriv platform is user-friendly and making deposits and withdrawals is easy." />
-    ),
-    index: 4,
-}
-
-const vipul = {
-    name: 'Vipul Kumar',
-    location: <Localize translate_text="India" />,
-    img_path: VipulImage,
-    quote: (
-        <Localize translate_text="The Deriv platform looks good and is easy to use. The withdrawal process is pretty simple and can be done in just a few clicks." />
-    ),
-    index: 5,
-}
-
-const manikandan = {
-    name: 'Manikandan',
-    location: <Localize translate_text="India" />,
-    img_path: ManikandanImage,
-    quote: (
-        <Localize translate_text="I have more than a decade’s worth of online trading experience, and I think that Deriv is one of the best brokers in the world. I like the new features on the Deriv platform. Being able to trade on weekends on volatility indices is a plus." />
-    ),
-    index: 6,
-}
-
-const jose = {
-    name: 'José Miguel Santos Martinez',
-    location: <Localize translate_text="Dominican Republic" />,
-    img_path: JoseImage,
-    quote: (
-        <Localize translate_text="The Deriv platform is very attractive, intuitive, and user-friendly, and it’s equipped with all the tools I need." />
-    ),
-    index: 7,
-}
-
-const vilca = {
-    name: 'Paul Vilca',
-    location: <Localize translate_text="Peru" />,
-    img_path: VilcaImage,
-    quote: (
-        <Localize translate_text="I like using the new Deriv platform because it’s so intuitive; I don’t need any tutorials to learn how to use it. The dark mode option on DTrader is very pleasing to my eyes. The ability to set my trade duration to ticks, seconds, and minutes is something I don’t see on other platforms." />
-    ),
-    index: 8,
-}
-
-const fernando = {
-    name: 'Fernando Aguilar',
-    location: <Localize translate_text="Bolivia" />,
-    img_path: FernandoImage,
-    quote: (
-        <Localize translate_text="I’ve been trading on Deriv for a while now, and I think it’s very appealing to traders who are just starting out. It’s easy to understand and all my trading information is very accessible. There are a variety of assets, trade contracts, chart types, and indicators for technical analysis." />
-    ),
-    index: 9,
-}
-
 const our_client_slides = [
-    fabio,
-    mugenda,
-    tuelo,
-    mustafijur,
-    vipul,
-    manikandan,
-    jose,
-    vilca,
-    fernando,
+    {
+        id: 'fabio',
+        name: 'Fábio Oliveira',
+        location: <Localize translate_text="Kenya" />,
+        quote: (
+            <Localize translate_text="It surpassed my expectations. Binary got it right with Deriv. Trading on the platform is excellent and it allows for making accurate graphical analyses of the market and adding support and resistance markings with the use of horizontal lines, RSI, FIBO and much more." />
+        ),
+    },
+    {
+        id: 'mugenda',
+        name: 'Paul Mugenda',
+        location: <Localize translate_text="Kenya" />,
+        quote: (
+            <Localize translate_text="The Deriv platform is fast, easy to navigate, and very user-friendly. It looks great and it’s packed with many appealing features. Deposits and withdrawals are easy. My favourite markets to trade on are the Crash and Boom indices on MT5." />
+        ),
+    },
+    {
+        id: 'tuelo',
+        name: 'Tuelo Ronald Boitshwarelo',
+        location: <Localize translate_text="Botswana" />,
+        quote: (
+            <Localize translate_text="What I like most is that my withdrawals are processed fast. This is the platform of the future: it offers more functionality as well as different ways to trade. No other broker has given me the same satisfaction as Deriv has. A great broker indeed." />
+        ),
+    },
+    {
+        id: 'mustafijur',
+        name: 'Mustafijur Rahman',
+        location: <Localize translate_text="Bangladesh" />,
+        quote: (
+            <Localize translate_text="The Deriv platform is user-friendly and making deposits and withdrawals is easy." />
+        ),
+    },
+    {
+        id: 'vipul',
+        name: 'Vipul Kumar',
+        location: <Localize translate_text="India" />,
+        quote: (
+            <Localize translate_text="The Deriv platform looks good and is easy to use. The withdrawal process is pretty simple and can be done in just a few clicks." />
+        ),
+    },
+    {
+        id: 'manikandan',
+        name: 'Manikandan',
+        location: <Localize translate_text="India" />,
+        quote: (
+            <Localize translate_text="I have more than a decade’s worth of online trading experience, and I think that Deriv is one of the best brokers in the world. I like the new features on the Deriv platform. Being able to trade on weekends on volatility indices is a plus." />
+        ),
+    },
+    {
+        id: 'jose',
+        name: 'José Miguel Santos Martinez',
+        location: <Localize translate_text="Dominican Republic" />,
+        quote: (
+            <Localize translate_text="The Deriv platform is very attractive, intuitive, and user-friendly, and it’s equipped with all the tools I need." />
+        ),
+    },
+    {
+        id: 'vilca',
+        name: 'Paul Vilca',
+        location: <Localize translate_text="Peru" />,
+        quote: (
+            <Localize translate_text="I like using the new Deriv platform because it’s so intuitive; I don’t need any tutorials to learn how to use it. The dark mode option on DTrader is very pleasing to my eyes. The ability to set my trade duration to ticks, seconds, and minutes is something I don’t see on other platforms." />
+        ),
+    },
+    {
+        id: 'fernando',
+        name: 'Fernando Aguilar',
+        location: <Localize translate_text="Bolivia" />,
+        quote: (
+            <Localize translate_text="I’ve been trading on Deriv for a while now, and I think it’s very appealing to traders who are just starting out. It’s easy to understand and all my trading information is very accessible. There are a variety of assets, trade contracts, chart types, and indicators for technical analysis." />
+        ),
+    },
 ]
 
+const query = graphql`
+    query {
+        fabio: file(relativePath: { eq: "fabio.png" }) {
+            ...fadeIn
+        }
+        mugenda: file(relativePath: { eq: "paul-mugenda.png" }) {
+            ...fadeIn
+        }
+        tuelo: file(relativePath: { eq: "tuelo.png" }) {
+            ...fadeIn
+        }
+        mustafijur: file(relativePath: { eq: "mustafijur.png" }) {
+            ...fadeIn
+        }
+        vipul: file(relativePath: { eq: "vipul.png" }) {
+            ...fadeIn
+        }
+        manikandan: file(relativePath: { eq: "manikandan.png" }) {
+            ...fadeIn
+        }
+        jose: file(relativePath: { eq: "jose.png" }) {
+            ...fadeIn
+        }
+        vilca: file(relativePath: { eq: "paul-vilca.png" }) {
+            ...fadeIn
+        }
+        fernando: file(relativePath: { eq: "fernando.png" }) {
+            ...fadeIn
+        }
+    }
+`
+
 const WhatOurClientsSay = () => {
+    const data = useStaticQuery(query)
     const settings = {
         options: {
             loop: true,
@@ -245,7 +243,7 @@ const WhatOurClientsSay = () => {
                                 quote={trader.quote}
                                 name={trader.name}
                                 location={trader.location}
-                                img_path={trader.img_path}
+                                img={data[trader.id]}
                                 img_alt={trader.name + localize(" - Deriv's Client")}
                             />
                         </div>

--- a/src/pages/home/_what-our-clients-say.js
+++ b/src/pages/home/_what-our-clients-say.js
@@ -236,17 +236,15 @@ const WhatOurClientsSay = () => {
                     </Header>
                 </Container>
                 <Carousel has_autoplay autoplay_interval={4000} {...settings}>
-                    {our_client_slides.map((trader, idx) => (
-                        <div key={idx}>
-                            <ClientSlide
-                                key={trader.name}
-                                quote={trader.quote}
-                                name={trader.name}
-                                location={trader.location}
-                                img={data[trader.id]}
-                                img_alt={trader.name + localize(" - Deriv's Client")}
-                            />
-                        </div>
+                    {our_client_slides.map((trader) => (
+                        <ClientSlide
+                            key={trader.id}
+                            quote={trader.quote}
+                            name={trader.name}
+                            location={trader.location}
+                            img={data[trader.id]}
+                            img_alt={trader.name + localize(" - Deriv's Client")}
+                        />
                     ))}
                 </Carousel>
             </StyledSection>


### PR DESCRIPTION
Changes:
Added default config for gatsby images. The config will perform the following:
- Strip all image metadata (exif, etc)
- Default to 50% quality (for all format including generated webp)
- Add exact image sizes
- Removed specific breakpoints. Based on test the breakpoints generated by Gatsby covers 90% of our screen sizes.
- Refactored some codebase to use `QueryImage` instead of loading the images directly

## Type of change

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [x] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [x] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
