### PR TITLE
Nuri/udpate: add USD currency in front of 2M in p2p v1 and v2 page

### DIFF
--- a/src/pages/p2p/components/_numbers.js
+++ b/src/pages/p2p/components/_numbers.js
@@ -12,7 +12,7 @@ const content = [
         text: <Localize translate_text="active users" />,
     },
     {
-        header: <Localize translate_text="2M" />,
+        header: <Localize translate_text="USD 2M" />,
         text: <Localize translate_text="exchanged to date" />,
     },
 ]


### PR DESCRIPTION
Changes:

-   Add 'USD' in front of 2M in numbers component for p2p v1 and v2 page.

## Type of change

-   [ ] Bug fix
-   [ ] New feature
-   [X] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [X] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
