### PR TITLE
Sean / feat(marketing): add marketing data from url or cookies into deriv store

### DIFF
--- a/src/components/custom/signup.js
+++ b/src/components/custom/signup.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { graphql, StaticQuery } from 'gatsby'
 import styled from 'styled-components'
-import Cookies from 'js-cookie'
 import { getCookiesObject, getCookiesFields, getDataObjFromCookies } from 'common/cookies'
 import { Box } from 'components/containers'
 import Login from 'common/login'
@@ -16,6 +15,7 @@ import SignupSimple from 'components/custom/_signup-simple'
 import { Header, QueryImage, StyledLink, Text } from 'components/elements'
 import { localize, Localize } from 'components/localization'
 import device from 'themes/device.js'
+import { DerivStore } from 'store'
 
 const Form = styled.form`
     height: 100%;
@@ -90,7 +90,7 @@ class Signup extends Component {
     }
 
     getVerifyEmailRequest = (email) => {
-        const affiliate_token = Cookies.getJSON('affiliate_tracking')
+        const { affiliate_token } = React.useContext(DerivStore)
 
         const cookies = getCookiesFields()
         const cookies_objects = getCookiesObject(cookies)

--- a/src/components/hooks/use-marketing-data.js
+++ b/src/components/hooks/use-marketing-data.js
@@ -1,0 +1,30 @@
+import { useState, useEffect } from 'react'
+import Cookies from 'js-cookie'
+import { isBrowser } from 'common/utility'
+
+export const useMarketingData = () => {
+    const [affiliate_token, setAffiliateToken] = useState(null)
+    const [utm_data, setUtmData] = useState(null)
+
+    const affiliate_token_cookie = Cookies.get('affiliate_token')
+    const utm_data_cookie = Cookies.get('utm_data')
+
+    const url_params = new URLSearchParams((isBrowser() && window.location.search) || '')
+    const affiliate_token_url = url_params.get('affiliate_token')
+    const utm_data_url = url_params.get('utm_data')
+
+    useEffect(() => {
+        if (affiliate_token_cookie) {
+            setAffiliateToken(affiliate_token_cookie)
+        } else {
+            setAffiliateToken(affiliate_token_url)
+        }
+        if (utm_data_cookie) {
+            setUtmData(utm_data_cookie)
+        } else {
+            setUtmData(utm_data_url)
+        }
+    }, [url_params])
+
+    return [affiliate_token, utm_data]
+}

--- a/src/components/hooks/use-marketing-data.js
+++ b/src/components/hooks/use-marketing-data.js
@@ -5,24 +5,24 @@ import { isBrowser } from 'common/utility'
 export const useMarketingData = () => {
     const [affiliate_token, setAffiliateToken] = useState(null)
     const [utm_data, setUtmData] = useState(null)
-
+    // Extract from cookies
     const affiliate_token_cookie = Cookies.get('affiliate_token')
     const utm_data_cookie = Cookies.get('utm_data')
-
+    // Extract from url params
     const url_params = new URLSearchParams((isBrowser() && window.location.search) || '')
-    const affiliate_token_url = url_params.get('affiliate_token')
-    const utm_data_url = url_params.get('utm_data')
+    const affiliate_token_params = url_params.get('affiliate_token')
+    const utm_data_params = url_params.get('utm_data')
 
     useEffect(() => {
         if (affiliate_token_cookie) {
             setAffiliateToken(affiliate_token_cookie)
         } else {
-            setAffiliateToken(affiliate_token_url)
+            setAffiliateToken(affiliate_token_params ?? affiliate_token_cookie)
         }
         if (utm_data_cookie) {
             setUtmData(utm_data_cookie)
         } else {
-            setUtmData(utm_data_url)
+            setUtmData(utm_data_params ?? utm_data_cookie)
         }
     }, [url_params])
 

--- a/src/components/hooks/use-marketing-data.js
+++ b/src/components/hooks/use-marketing-data.js
@@ -14,8 +14,8 @@ export const useMarketingData = () => {
     const utm_data_params = url_params.get('utm_data')
 
     useEffect(() => {
-        setAffiliateToken(affiliate_token_params ?? affiliate_token_cookie)
-        setUtmData(utm_data_params ?? utm_data_cookie)
+        setAffiliateToken(affiliate_token_params ?? affiliate_token_cookie ?? null)
+        setUtmData(utm_data_params ?? utm_data_cookie ?? null)
     }, [url_params])
 
     return [affiliate_token, utm_data]

--- a/src/components/hooks/use-marketing-data.js
+++ b/src/components/hooks/use-marketing-data.js
@@ -14,16 +14,8 @@ export const useMarketingData = () => {
     const utm_data_params = url_params.get('utm_data')
 
     useEffect(() => {
-        if (affiliate_token_cookie) {
-            setAffiliateToken(affiliate_token_cookie)
-        } else {
-            setAffiliateToken(affiliate_token_params ?? affiliate_token_cookie)
-        }
-        if (utm_data_cookie) {
-            setUtmData(utm_data_cookie)
-        } else {
-            setUtmData(utm_data_params ?? utm_data_cookie)
-        }
+        setAffiliateToken(affiliate_token_params ?? affiliate_token_cookie)
+        setUtmData(utm_data_params ?? utm_data_cookie)
     }, [url_params])
 
     return [affiliate_token, utm_data]

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,12 +1,14 @@
 import React, { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import { useWebsiteStatus } from 'components/hooks/website-status-hooks'
+import { useMarketingData } from 'components/hooks/use-marketing-data'
 import { isEuCountry, isP2PAllowedCountry } from 'common/country-base'
 
 export const DerivStore = React.createContext()
 
 export const DerivProvider = ({ children }) => {
     const [website_status] = useWebsiteStatus()
+    const [affiliate_token, utm_data] = useMarketingData()
     const [is_eu_country, setEuCountry] = useState(null)
     const [is_p2p_allowed_country, setP2PAllowedCountry] = useState(false)
     const [crypto_config, setCryptoConfig] = useState(null)
@@ -24,9 +26,11 @@ export const DerivProvider = ({ children }) => {
     return (
         <DerivStore.Provider
             value={{
+                affiliate_token,
+                crypto_config,
                 is_eu_country,
                 is_p2p_allowed_country,
-                crypto_config,
+                utm_data,
             }}
         >
             {children}


### PR DESCRIPTION
Changes:

-   Add hook to extract marketing data either from url params or cookies
-   Handle marketing data globally in deriv store
-   Pull affiliate token in signup page from store 

## Type of change

-   [ ] Bug fix
-   [x] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
