### PR TITLE
habib/add spacing fix login button

### DIFF
--- a/src/components/layout/nav.js
+++ b/src/components/layout/nav.js
@@ -362,7 +362,7 @@ const LinkMobileLogin = styled(LinkButton)`
     font-size: 14px;
     @media ${device.tabletL} {
         display: block;
-        margin-left: auto;
+        margin-left: 0.8rem;
     }
     @media ${device.mobileL} {
         font-size: var(--text-size-xxs);

--- a/src/components/layout/nav.js
+++ b/src/components/layout/nav.js
@@ -366,6 +366,7 @@ const LinkMobileLogin = styled(LinkButton)`
     }
     @media ${device.mobileL} {
         font-size: var(--text-size-xxs);
+        margin-left: 0.8rem;
     }
 `
 const handleScroll = (show, hide) => {


### PR DESCRIPTION
Changes:

Issue: Space between "Log in" button and language icon is more than usual in responsive mode.

Step 1: Navigate to https://deriv-com-3j1raadnt.binary.sx/es/partners/
Step 2: From the side menu tap on Affiliates and iB's page

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [x] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
