### PR TITLE
Sean / fix: overflowing text for some languages in CFD banner

### DIFF
--- a/src/components/layout/layout.js
+++ b/src/components/layout/layout.js
@@ -35,19 +35,35 @@ const CFDWrapper = styled.section`
     display: flex;
     align-items: center;
 
+    @media ${device.tabletL} {
+        overflow-y: scroll;
+        display: block;
+    }
     @media ${device.tabletS} {
         height: ${cfd_warning_height.tablet}rem;
     }
 `
 
 const CFDContainer = styled(Container)`
+    @media ${device.bp1060} {
+        width: 90%;
+    }
     @media ${device.tabletL} {
         width: 95%;
+    }
+    @media ${device.tabletS} {
+        margin: 1rem auto;
+    }
+    @media ${device.mobileL} {
+        margin: 2rem auto;
+    }
+    @media ${device.mobileM} {
+        margin: 1rem auto;
     }
 `
 
 const CFDText = styled(Text)`
-    @media ${device.tabletL} {
+    @media ${device.bp1060} {
         font-size: 14px;
     }
 


### PR DESCRIPTION
Changes:

-   Fix: overflowing text for some languages (FR, PL, ID, IT) in CFD banner

## Type of change

-   [X] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
