### PR TITLE
Sean/fix: footer links not hover-able for calculator pages

### DIFF
--- a/src/pages/trader-tools/common/_style.js
+++ b/src/pages/trader-tools/common/_style.js
@@ -311,6 +311,7 @@ export const StyledOl = styled.ol`
 export const LinkWrapper = styled(Flex)`
     margin-top: 40px;
     justify-content: flex-start;
+    height: auto;
 
     @media ${device.laptop} {
         flex-direction: column-reverse;

--- a/src/pages/trader-tools/common/_style.js
+++ b/src/pages/trader-tools/common/_style.js
@@ -311,7 +311,6 @@ export const StyledOl = styled.ol`
 export const LinkWrapper = styled(Flex)`
     margin-top: 40px;
     justify-content: flex-start;
-    height: auto;
 
     @media ${device.laptop} {
         flex-direction: column-reverse;

--- a/src/pages/trader-tools/margin-calculator/_margin-calculator.js
+++ b/src/pages/trader-tools/margin-calculator/_margin-calculator.js
@@ -479,7 +479,7 @@ const MarginCalculator = () => {
                             </AccordionItem>
                         </Accordion>
 
-                        <LinkWrapper>
+                        <LinkWrapper height="auto">
                             <StyledLinkButton
                                 tertiary="true"
                                 is_deriv_app_link

--- a/src/pages/trader-tools/swap-calculator/_swap-calculator.js
+++ b/src/pages/trader-tools/swap-calculator/_swap-calculator.js
@@ -561,7 +561,7 @@ const SwapCalculator = () => {
                                     </AccordionItem>
                                 </Accordion>
 
-                                <LinkWrapper>
+                                <LinkWrapper height="auto">
                                     {
                                         <StyledLinkButton
                                             tertiary="true"


### PR DESCRIPTION
Changes:

-   Fix: footer links not hover-able for calculator pages

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
