### PR TITLE
Sean/fix: footer links not hoverable for financial swap calculator page

### DIFF
--- a/src/pages/trader-tools/swap-calculator/_swap-calculator.js
+++ b/src/pages/trader-tools/swap-calculator/_swap-calculator.js
@@ -886,7 +886,7 @@ const SwapCalculator = () => {
                                         </Text>
                                     </AccordionItem>
                                 </Accordion>
-                                <LinkWrapper>
+                                <LinkWrapper height="auto">
                                     <StyledLinkButton
                                         tertiary="true"
                                         is_deriv_app_link


### PR DESCRIPTION
Changes:

-   

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
