### PR TITLE
Habib/change lang clicking deriv logo

### DIFF
--- a/src/common/utility.js
+++ b/src/common/utility.js
@@ -177,6 +177,6 @@ export const getDomain = () =>
 export const getLocalizedUrl = (path, is_index, to) => `/${path}${is_index ? `` : to}`
 
 export const nonENLangUrlReplace = (current_path) => {
-    const path_with_or_without_slash = /\/.+?(\/)|(\/\w+)/u
+    const path_with_or_without_slash = /\/.+?(\/)|(\/[a-zA-Z'-]+)/u
     return current_path.replace(path_with_or_without_slash, '')
 }


### PR DESCRIPTION
Changes:


Changing languages after clicking on deriv logo, still breaks the page. So far observed with pl to zh-cn, pl to zh-tw, it to zh-tw, th to zh-tw, etc. Happens quite frequently.

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
