### PR TITLE
nikolai.berestevich Bug #21338 ***fix*** besquare page 1st img and "why besquare "column text margin/padding were changed 

### DIFF
--- a/src/pages/besquare/components/sections/_what-is_besquare.js
+++ b/src/pages/besquare/components/sections/_what-is_besquare.js
@@ -37,7 +37,7 @@ const WhatIsBeSquare = () => {
     return (
         <Section>
             <ContentContainer>
-                <ContentWrapper margin={'120px'}>
+                <ContentWrapper>
                     <Title as="h2" text_align={'left'} max_width={['450px']} margin={['0', '0 auto']}>
                         {what_is_be_square.title}
                     </Title>

--- a/src/pages/besquare/components/sections/_what-is_besquare.js
+++ b/src/pages/besquare/components/sections/_what-is_besquare.js
@@ -41,7 +41,7 @@ const WhatIsBeSquare = () => {
                     <Title as="h2" text_align={'left'} max_width={['450px']} margin={['0', '0 auto']}>
                         {what_is_be_square.title}
                     </Title>
-                    <TextWrapper max_width={['486px', '328px']} margin={['8px 0 0', '16px 0 16px 0']} >
+                    <TextWrapper max_width={['486px', '328px']} margin={['8px 0 0', '16px 0']} >
                         {what_is_be_square.subtitle}
                     </TextWrapper>
                 </ContentWrapper>

--- a/src/pages/besquare/components/sections/_what-is_besquare.js
+++ b/src/pages/besquare/components/sections/_what-is_besquare.js
@@ -25,8 +25,8 @@ const WhatIsBeSquare = () => {
             margin: ['12px 0 0 16px', '14px 0 0 12px'],
         },
         text_wrapper: {
-            max_width: ['446px', '328px'],
-            padding: ['8px 8px 8px 0', '12px 12px 12px 0'],
+            max_width: ['446px', '282px'],
+            padding: ['8px 8px 8px 0', '12px 0px 12px 0'],
         },
     }
 
@@ -37,11 +37,11 @@ const WhatIsBeSquare = () => {
     return (
         <Section>
             <ContentContainer>
-                <ContentWrapper>
-                    <Title as="h2" text_align={'left'} max_width={['282px']} margin={['0', '0 auto']}>
+                <ContentWrapper margin={'120px'}>
+                    <Title as="h2" text_align={'left'} max_width={['450px']} margin={['0', '0 auto']}>
                         {what_is_be_square.title}
                     </Title>
-                    <TextWrapper max_width={['486px', '292px']} margin={['8px 0 0', '16px 0']}>
+                    <TextWrapper max_width={['486px', '328px']} margin={['8px 0 0', '16px 0 16px 0']} >
                         {what_is_be_square.subtitle}
                     </TextWrapper>
                 </ContentWrapper>

--- a/src/pages/besquare/components/sections/_what-is_besquare.js
+++ b/src/pages/besquare/components/sections/_what-is_besquare.js
@@ -26,7 +26,7 @@ const WhatIsBeSquare = () => {
         },
         text_wrapper: {
             max_width: ['446px', '282px'],
-            padding: ['8px 8px 8px 0', '12px 0px 12px 0'],
+            padding: ['8px 8px 8px 0', '12px 12px 12px 0'],
         },
     }
 

--- a/src/pages/besquare/static/style/_hero.js
+++ b/src/pages/besquare/static/style/_hero.js
@@ -12,6 +12,10 @@ export const HeroContainer = styled.div`
     @media ${device.laptop} {
         grid-template-columns: auto;
     }
+    
+    @media ${device.tablet} {
+        height: 370px;
+    }
 `
 
 export const HeaderContainer = styled(Container)`
@@ -31,8 +35,8 @@ export const ImageWrapper = styled.img`
     top: 90px;
 
     @media ${device.tablet} {
-        max-width: 328px;
-        margin-right: 15px;
+        max-width: 298px;
+        margin: 0 auto;
         overflow: unset;
         top: 24px;
     }

--- a/src/pages/besquare/static/style/_hero.js
+++ b/src/pages/besquare/static/style/_hero.js
@@ -34,6 +34,6 @@ export const ImageWrapper = styled.img`
         max-width: 328px;
         margin-right: 15px;
         overflow: unset;
-        top: 40px;
+        top: 24px;
     }
 `


### PR DESCRIPTION
Changes:
-   the 1st image's top padding was decreased
- "why besquare?" column : changes of style  for good view  on screen with width 320-330px

## Type of change

-   [ x ] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ x ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
