### PR TITLE
Using $GITHUB_SHA instead of $GIT_TAG_NAME

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -72,13 +72,13 @@ jobs:
         # with:
         #   tagRegex: "staging(.*)"
       - name: Building docker image 🐳
-        run: docker build -t ${{ secrets.DOCKHUB_ORGANISATION }}/deriv-com:latest-staging  -t ${{ secrets.DOCKHUB_ORGANISATION }}/deriv-com:$GIT_TAG_NAME . 
+        run: docker build -t ${{ secrets.DOCKHUB_ORGANISATION }}/deriv-com:latest-staging  -t ${{ secrets.DOCKHUB_ORGANISATION }}/deriv-com:$GITHUB_SHA .
 
       - name: Pushing Image to docker hub 🐳
         run: |
           echo ${{ secrets.DOCKERHUB_PASSWORD }}| docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
           docker push  ${{ secrets.DOCKHUB_ORGANISATION }}/deriv-com:latest-staging
-          docker push  ${{ secrets.DOCKHUB_ORGANISATION }}/deriv-com:$GIT_TAG_NAME
+          docker push  ${{ secrets.DOCKHUB_ORGANISATION }}/deriv-com:$GITHUB_SHA
 
       - name: Deploy 🚀
         run: |
@@ -90,7 +90,7 @@ jobs:
           git clone https://github.com/binary-com/devops-ci-scripts
           cd devops-ci-scripts/k8s-build_tools
           echo ${{ secrets.CA_CRT}} | base64 --decode > ca.crt
-          ./release.sh deriv-com $GIT_TAG_NAME
+          ./release.sh deriv-com $GITHUB_SHA
 
       - name: Slack Notification 📣
         uses: 8398a7/action-slack@v3
@@ -102,7 +102,7 @@ jobs:
             {
               attachments: [{
                 color: '${{ job.status }}' === 'success' ? 'good' : '${{ job.status }}' === 'failure' ? 'danger' : 'warning',
-                text: `Release for *Deriv.com* with version *$GIT_TAG_NAME*`
+                text: `Release for *Deriv.com* with version *$GITHUB_SHA*`
               }]
             }
         env:


### PR DESCRIPTION
Because we don't use tag for releasing staging

Changes:

-   ...

## Type of change

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
