### PR TITLE
nikolai.berestevich/style/copyright to left #35694

### DIFF
--- a/src/components/layout/footer/common/style.js
+++ b/src/components/layout/footer/common/style.js
@@ -188,7 +188,6 @@ export const CopyrightWrapper = styled(Flex)`
         width: 90%;
         margin: 0 auto;
         padding: 2rem 0;
-        justify-content: center;
 
         p {
             font-size: 1.75rem;


### PR DESCRIPTION
Changes:

-   homepage: 
  Mobile: Copyright text change : now it is left aligned

## Type of change

-   [ x ] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ x ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
