### PR TITLE
nikolai.berestevich/refactor/delete-alt-tags-resourses

### DIFF
--- a/src/pages/trader-tools/_tools.js
+++ b/src/pages/trader-tools/_tools.js
@@ -143,7 +143,7 @@ const TradingTools = ({ tools }) => {
                                     <Show.Mobile>
                                         <QueryImage
                                             data={data[item.image_name + '_mobile']}
-                                            alt="           "
+                                            alt=""
                                             height="100%"
                                         />
                                         <StyledLinkButton tertiary to={item.link.route}>

--- a/src/pages/trader-tools/_tools.js
+++ b/src/pages/trader-tools/_tools.js
@@ -136,14 +136,14 @@ const TradingTools = ({ tools }) => {
                                     <Show.Desktop>
                                         <QueryImage
                                             data={data[item.image_name]}
-                                            alt={item.image_alt}
+                                            alt=""
                                             height="100%"
                                         />
                                     </Show.Desktop>
                                     <Show.Mobile>
                                         <QueryImage
                                             data={data[item.image_name + '_mobile']}
-                                            alt={item.image_alt}
+                                            alt="           "
                                             height="100%"
                                         />
                                         <StyledLinkButton tertiary to={item.link.route}>


### PR DESCRIPTION
Changes:

-   change alt tags to '' on Resources's pages excluding /blog

## Type of change

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ x ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
