### PR TITLE
fix: expanded height of tags when title is one line long

### DIFF
--- a/src/pages/academy/_recent-featured-posts.js
+++ b/src/pages/academy/_recent-featured-posts.js
@@ -134,6 +134,7 @@ const RecentFeaturedPosts = ({ recent_data, featured_data }) => {
                                                     <SmallArticleTopContent>
                                                         <Flex
                                                             jc="start"
+                                                            height="unset"
                                                             laptopM={{ flexDirection: 'start' }}
                                                         >
                                                             {article.tags &&
@@ -244,6 +245,7 @@ const RecentFeaturedPosts = ({ recent_data, featured_data }) => {
                                                     <SmallArticleTopContent>
                                                         <Flex
                                                             jc="start"
+                                                            height="unset"
                                                             laptopM={{ flexDirection: 'start' }}
                                                         >
                                                             {article.tags &&


### PR DESCRIPTION
Changes:

-   Fix expanded height of tags when title is one line long

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
