### PR TITLE
"Footer banner from https://deriv.com/dtrader/ in 1366px between logo and text" - fixed

### DIFF
--- a/src/components/custom/_dbanner.js
+++ b/src/components/custom/_dbanner.js
@@ -77,6 +77,9 @@ const TextWrapper = styled.div`
         margin-top: 35px;
         margin-bottom: 40px;
     }
+    @media (min-width: 1351px) and (max-width: 1385px) {
+        margin-right: 60px;
+    }
 `
 const DemoButton = styled.div`
     text-align: center;


### PR DESCRIPTION
Changes:

-   Footer banner from https://deriv.com/dtrader/ in 1351px - 1385 between logo and text add @media margin 

## Type of change

-   [ x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
