### PR TITLE
nikolai.berestevich/fix/margin links

### DIFF
--- a/src/pages/landing/ebooks/components/_get-ebook.js
+++ b/src/pages/landing/ebooks/components/_get-ebook.js
@@ -17,7 +17,6 @@ import Facebook from 'images/svg/custom/facebook-blue.svg'
 import Google from 'images/svg/custom/google.svg'
 import ViewEmailImage from 'images/common/sign-up/view-email.png'
 
-
 const SignupFormWrapper = styled(Flex)`
     width: 50%;
     align-items: center;

--- a/src/pages/trader-tools/margin-calculator/_margin-calculator.js
+++ b/src/pages/trader-tools/margin-calculator/_margin-calculator.js
@@ -379,7 +379,7 @@ const MarginCalculator = () => {
                             >
                                 {localize('Go to DMT5 dashboard')}
                             </StyledLinkButton>
-                            <StyledLinkButton secondary="true" to="/trade-types/margin/">
+                            <StyledLinkButton secondary="true" to="/trade-types/cfds/">
                                 {localize('Learn more about margin')}
                             </StyledLinkButton>
                         </LinkWrapper>

--- a/src/pages/trader-tools/swap-calculator/_swap-calculator.js
+++ b/src/pages/trader-tools/swap-calculator/_swap-calculator.js
@@ -447,10 +447,7 @@ const SwapCalculator = () => {
                                         </StyledLinkButton>
                                     }
                                     {
-                                        <StyledLinkButton
-                                            secondary="true"
-                                            to="/trade-types/margin#swap-policy/"
-                                        >
+                                        <StyledLinkButton secondary="true" to="/trade-types/cfds/">
                                             {localize('Learn more about swap')}
                                         </StyledLinkButton>
                                     }
@@ -777,10 +774,7 @@ const SwapCalculator = () => {
                                     >
                                         {localize('Go to DMT5 dashboard')}
                                     </StyledLinkButton>
-                                    <StyledLinkButton
-                                        secondary="true"
-                                        to="/trade-types/margin#swap-policy/"
-                                    >
+                                    <StyledLinkButton secondary="true" to="/trade-types/cfds/">
                                         {localize('Learn more about swap')}
                                     </StyledLinkButton>
                                 </LinkWrapper>


### PR DESCRIPTION
Changes:

- /trade-types/margin/ links replaced  with  /trade-types/cfds/ to avoid  autoredirection

## Type of change

-   [x ] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
