### PR TITLE
nikolai.berestevich/fix/academy-video-bug after pressing space

### DIFF
--- a/src/pages/academy/components/_video-player.js
+++ b/src/pages/academy/components/_video-player.js
@@ -93,13 +93,10 @@ const VideoPlayer = ({ video_src, closeVideo }) => {
             }
         }
         vidElement.focus()
-        return document.removeEventListener('keydown', handleKeyboardEvent, false)
+        return () => document.removeEventListener('keydown', handleKeyboardEvent, false)
     }, [])
 
     const handleKeyboardEvent = (e) => {
-        if (e.code === 'Space') {
-            vidElement.paused ? vidElement.play() : vidElement.pause()
-        }
         if (e.key === 'Escape') {
             closeVideo()
         }


### PR DESCRIPTION
Changes:

-   made fix "Video is closed but sound is still there page is also freezed" by catching "Space" button event

## Type of change

-   [ x ] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
