### PR TITLE
KolesnikN/move CHF/JPY from exotic to minor pairs

### DIFF
--- a/src/pages/markets/instruments/_market-symbols.js
+++ b/src/pages/markets/instruments/_market-symbols.js
@@ -163,10 +163,6 @@ export const exotic_pairs = [
         text: <Localize translate_text="AUD/SGD" />,
     },
     {
-        src: icons.CHFJPY,
-        text: <Localize translate_text="CHF/JPY" />,
-    },
-    {
         src: icons.EURHKD,
         text: <Localize translate_text="EUR/HKD" />,
     },
@@ -423,6 +419,10 @@ export const minor_pairs = [
     {
         src: icons.NZDJPY,
         text: <Localize translate_text="NZD/JPY" />,
+    },
+    {
+        src: icons.CHFJPY,
+        text: <Localize translate_text="CHF/JPY" />,
     },
     {
         src: icons.NZDUSD,

--- a/src/pages/markets/instruments/_market-symbols.js
+++ b/src/pages/markets/instruments/_market-symbols.js
@@ -397,6 +397,10 @@ export const minor_pairs = [
         text: <Localize translate_text="AUD/NZD" />,
     },
     {
+        src: icons.CHFJPY,
+        text: <Localize translate_text="CHF/JPY" />,
+    },
+    {
         src: icons.EURNZD,
         text: <Localize translate_text="EUR/NZD" />,
     },
@@ -419,10 +423,6 @@ export const minor_pairs = [
     {
         src: icons.NZDJPY,
         text: <Localize translate_text="NZD/JPY" />,
-    },
-    {
-        src: icons.CHFJPY,
-        text: <Localize translate_text="CHF/JPY" />,
     },
     {
         src: icons.NZDUSD,


### PR DESCRIPTION
Changes:

-   Move CHF/JPY from exotic pairs to minor pairs

## Type of change

-   [ ] Bug fix
-   [ ] New feature
-   [x] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
