### PR TITLE
chore: update eslint config to allow no explicit return type

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -17,6 +17,9 @@
             "plugin:import/errors",
             "plugin:import/warnings"
         ],
+        "rules": {
+            "@typescript-eslint/explicit-module-boundary-types": "off"
+        },
         "parserOptions": {
             "project": "./tsconfig.json",
             "ecmaVersion": 2020,

--- a/src/components/elements/checkbox.tsx
+++ b/src/components/elements/checkbox.tsx
@@ -63,7 +63,7 @@ const StyledCheckbox = styled.div<StyledCheckboxProps>`
     }
 `
 
-const Checkbox = ({ checked, secondary, id, bg, ...props }: CheckboxProps): React.ReactNode => (
+const Checkbox = ({ checked, secondary, id, bg, ...props }: CheckboxProps) => (
     <CheckboxContainer id={id}>
         <HiddenCheckbox checked={checked} {...props} />
         <StyledCheckbox checked={checked} secondary={secondary} background={bg}>

--- a/src/components/elements/query-image.tsx
+++ b/src/components/elements/query-image.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react'
+import React from 'react'
 import styled from 'styled-components'
 import { GatsbyImage, getImage, ImageDataLike } from 'gatsby-plugin-image'
 
@@ -32,7 +32,7 @@ const QueryImage = ({
     loading,
     width,
     ...props
-}: QueryImageProps): ReactElement => {
+}: QueryImageProps) => {
     const image = getImage(data)
     if (data) {
         return (

--- a/src/components/elements/video-player.tsx
+++ b/src/components/elements/video-player.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react'
+import React from 'react'
 import styled from 'styled-components'
 import device from 'themes/device'
 
@@ -29,12 +29,7 @@ type VideoPlayerProps = {
     src: string
 }
 
-const VideoPlayer = ({
-    controls,
-    mobile_max_width,
-    max_width,
-    src,
-}: VideoPlayerProps): ReactElement => {
+const VideoPlayer = ({ controls, mobile_max_width, max_width, src }: VideoPlayerProps) => {
     return (
         <PlayerWrapper max_width={max_width} mobile_max_width={mobile_max_width}>
             <Video controls={controls}>

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react'
+import React from 'react'
 import styled from 'styled-components'
 import { graphql, useStaticQuery } from 'gatsby'
 import { isBrowser } from 'common/utility'
@@ -39,7 +39,7 @@ const ButtonWrapper = styled.div`
     margin-top: 2.6rem;
 `
 
-const PageNotFound = (): ReactNode => {
+const PageNotFound = () => {
     const data = useStaticQuery(query)
     return (
         isBrowser() && (

--- a/src/pages/careers/besquare/components/sections/_highlights.tsx
+++ b/src/pages/careers/besquare/components/sections/_highlights.tsx
@@ -1,9 +1,9 @@
-import React, { ReactElement } from 'react'
+import React from 'react'
 import HighlightVideo from '../../static/videos/highlights.mp4'
 import { VideoPlayer } from 'components/elements'
 import { Flex } from 'components/containers'
 
-const Highlights = (): ReactElement => {
+const Highlights = () => {
     return (
         <Flex mb="80px">
             <VideoPlayer src={HighlightVideo} max_width="900px" mobile_max_width="90%" controls />

--- a/src/pages/check-email/_icon-grid.tsx
+++ b/src/pages/check-email/_icon-grid.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react'
+import React from 'react'
 import styled from 'styled-components'
 import device from 'themes/device'
 import { Text } from 'components/elements'
@@ -70,7 +70,7 @@ const GridContent = [
     },
 ]
 
-export const IconGrid = (): ReactElement => (
+export const IconGrid = () => (
     <Grid>
         {GridContent.map((item, index) => (
             <GridCol key={`key-${index}`}>

--- a/src/pages/derivx/_accounts.tsx
+++ b/src/pages/derivx/_accounts.tsx
@@ -106,7 +106,7 @@ const StyledText = styled(Text)`
     }
 `
 
-const Accounts = (): ReactElement => {
+const Accounts = () => {
     return (
         <Section>
             <StyledHeader

--- a/src/pages/derivx/_hero.tsx
+++ b/src/pages/derivx/_hero.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, ReactElement } from 'react'
+import React, { useState, useEffect, useCallback } from 'react'
 import { Localize, localize } from 'components/localization'
 import DHero from 'components/custom/_dhero-2'
 import { size } from 'themes/device'
@@ -7,7 +7,7 @@ import DerivXBG2 from 'images/svg/deriv-x/triangle-down.svg'
 import DerivXlogoL from 'images/svg/deriv-x/derivx-logo-light.svg'
 import { isBrowser } from 'common/utility'
 
-const Hero = (): ReactElement => {
+const Hero = () => {
     const [is_mobile, setMobile] = useState(false)
 
     const handleResizeWindow = useCallback(() => {

--- a/src/pages/derivx/_selling-points.tsx
+++ b/src/pages/derivx/_selling-points.tsx
@@ -58,7 +58,7 @@ const selling_points: SellingPointsType[] = [
     },
 ]
 
-const SellingPoints = (): ReactElement => {
+const SellingPoints = () => {
     return (
         <SectionContainer padding="40px 0" background="grey-25">
             <Container>

--- a/src/pages/derivx/_start-derivx.tsx
+++ b/src/pages/derivx/_start-derivx.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, ReactElement } from 'react'
+import React, { useState, useEffect, useCallback, ReactElement, ReactNode } from 'react'
 import styled, { css } from 'styled-components'
 import { graphql, useStaticQuery } from 'gatsby'
 import SideTab from '../dmt5/components/_side-tab'
@@ -10,7 +10,7 @@ import { isBrowser } from 'common/utility'
 import { derivx_android_url, derivx_ios_url } from 'common/constants'
 
 interface StartDerivXProps {
-    children?: React.ReactNode
+    children?: ReactNode
     active?: boolean
     mobile_padding?: string
 }
@@ -209,7 +209,7 @@ const StyledText = styled(Text)`
     }
 `
 
-const StartDerivX = (): ReactElement => {
+const StartDerivX = () => {
     const [is_mobile, setMobile] = useState(false)
     const handleResizeWindow = useCallback(() => {
         setMobile(isBrowser() ? window.screen.width <= size.tablet : false)

--- a/src/pages/derivx/_what-is-derivx.tsx
+++ b/src/pages/derivx/_what-is-derivx.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react'
+import React from 'react'
 import styled from 'styled-components'
 import { Localize } from 'components/localization'
 import { SectionContainer, Container, Flex } from 'components/containers'
@@ -19,7 +19,7 @@ const StyledSectionContainer = styled(SectionContainer)`
     }
 `
 
-const WhatIsDeriv = (): ReactElement => {
+const WhatIsDeriv = () => {
     return (
         <StyledSectionContainer>
             <Container>

--- a/src/pages/derivx/_why-trade-derivx.tsx
+++ b/src/pages/derivx/_why-trade-derivx.tsx
@@ -112,7 +112,7 @@ const card_data: CardType[] = [
     },
 ]
 
-const WhyTradeDerivX = (): ReactElement => {
+const WhyTradeDerivX = () => {
     return (
         <div>
             <SectionContainer>

--- a/src/pages/derivx/index.tsx
+++ b/src/pages/derivx/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, ReactElement } from 'react'
+import React, { useState, useEffect, useCallback } from 'react'
 import { graphql, StaticQuery } from 'gatsby'
 import { DBanner } from '../dmt5/_lazy-load'
 import Hero from './_hero'
@@ -23,7 +23,7 @@ const query = graphql`
     }
 `
 
-const DerivX = (): ReactElement => {
+const DerivX = () => {
     const [is_mobile, setMobile] = useState(false)
     const handleResizeWindow = useCallback(() => {
         setMobile(isBrowser() ? window.screen.width <= size.tablet : false)

--- a/src/pages/home/_trade-the-way-you-like.tsx
+++ b/src/pages/home/_trade-the-way-you-like.tsx
@@ -27,7 +27,7 @@ const query = graphql`
     }
 `
 
-const TradeTheWayYouLike = ({ is_ppc_redirect }: TradeTheWayYouLikeProps): React.ReactNode => {
+const TradeTheWayYouLike = ({ is_ppc_redirect }: TradeTheWayYouLikeProps) => {
     const data = useStaticQuery(query)
     return (
         <StyledSection padding="5rem 2rem">

--- a/src/pages/why-choose-us/_icon-grid.tsx
+++ b/src/pages/why-choose-us/_icon-grid.tsx
@@ -62,7 +62,7 @@ type ColProps = {
     title: string
 }
 
-const Col = ({ Icon, content, title }: ColProps): ReactElement => (
+const Col = ({ Icon, content, title }: ColProps) => (
     <GridCol>
         <img src={Icon} />
         <Container>
@@ -95,7 +95,7 @@ const GridWrapper = styled(CssGrid)`
     }
 `
 
-export const IconGrid = (): ReactElement => (
+export const IconGrid = () => (
     <GridContainer>
         <GridWrapper columns="repeat(3, 1fr)" column_gap="13rem" row_gap="10rem">
             <Col

--- a/src/pages/why-choose-us/index.tsx
+++ b/src/pages/why-choose-us/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react'
+import React from 'react'
 import styled from 'styled-components'
 import { IconGrid } from './_icon-grid'
 import { SEO, SectionContainer, GridContainer, Flex } from 'components/containers'
@@ -54,7 +54,7 @@ const ResponsiveHeader = styled(StyledHeader)`
     }
 `
 
-const WhyChooseUs = (): ReactNode => {
+const WhyChooseUs = () => {
     return (
         <Layout>
             <SEO

--- a/src/store/index.tsx
+++ b/src/store/index.tsx
@@ -8,7 +8,7 @@ type DerivProviderProps = {
 
 export const DerivStore = React.createContext()
 
-export const DerivProvider = ({ children }: DerivProviderProps): React.ReactNode => {
+export const DerivProvider = ({ children }: DerivProviderProps) => {
     const [website_status, setWebsiteStatus, website_status_loading] = useWebsiteStatus()
     const [is_eu_country, setEuCountry] = useState(null)
     const [is_p2p_allowed_country, setP2PAllowedCountry] = useState(false)


### PR DESCRIPTION
Changes:

-   Update eslint config to allow no explicit declaration of return type for React components

## Type of change

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [x] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
