### PR TITLE
Ako/ remove is_eager and use loading attribute instead

### DIFF
--- a/src/pages/home/_hero.js
+++ b/src/pages/home/_hero.js
@@ -185,7 +185,7 @@ const Hero = ({ is_ppc }) => {
                                     alt="Deriv's trading platform"
                                     width="100%"
                                     height="233"
-                                    is_eager
+                                    loading="eager"
                                 />
                             </Show.Mobile>
                         )}
@@ -195,7 +195,7 @@ const Hero = ({ is_ppc }) => {
                                 alt="Deriv's trading platform"
                                 width="100%"
                                 height="346"
-                                is_eager
+                                loading="eager"
                             />
                         </Show.Desktop>
                     </ImageWrapper>


### PR DESCRIPTION
Changes:
loading="eager" attribute missed in the homepage hero that cause the gatsby image extension to load the image lazily.
is_eager removed and loading attr added instead 
-   ...

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [x] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
