### PR TITLE
Ako/ load 404 first fold image eagerly

### DIFF
--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -53,6 +53,7 @@ const PageNotFound = () => {
                         <QueryImage
                             data={data['page_not_found']}
                             alt={localize('Page not found')}
+                            loading="eager"
                         />
                     </ImageWrapper>
 


### PR DESCRIPTION
To reduce LCP we should load image eagerly

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [x] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
