### PR TITLE
Ako/ add `passive:true` to scroll event listener of article component

### DIFF
--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -59,7 +59,7 @@ const ArticlesTemplate = (props) => {
     }
 
     useEffect(() => {
-        window.addEventListener('scroll', scrollFunc)
+        window.addEventListener('scroll', scrollFunc, { passive: true })
         return () => {
             window.removeEventListener('scroll', scrollFunc)
         }


### PR DESCRIPTION
Changes:
Added passive option to scroll event listener since it's a best practice to have a smooth scrolling 


## Type of change

-   [ ] Bug fix
-   [ ] New feature
-   [x] Update feature
-   [x] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
