### PR TITLE
yashim/fix: LCP for eager loading Images

### DIFF
--- a/src/components/elements/query-image.tsx
+++ b/src/components/elements/query-image.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 import { GatsbyImage, getImage, ImageDataLike } from 'gatsby-plugin-image'
 
 type QueryImageProps = {
@@ -15,12 +15,23 @@ type ImageWrapperProps = {
     width: string
     height: string
     className?: string
+    loading: 'eager' | 'lazy'
 }
 
 export const ImageWrapper = styled.div<ImageWrapperProps>`
     & .gatsby-image-wrapper {
         width: ${(props) => props.width || '100%'};
         height: ${(props) => props.height};
+    }
+    .gatsby-image-wrapper [data-main-image] {
+        ${(props) => {
+            if (props.loading === 'eager') {
+                return css`
+                    transition: none;
+                    opacity: 1;
+                `
+            }
+        }}
     }
 `
 
@@ -29,14 +40,14 @@ const QueryImage = ({
     className,
     data,
     height,
-    loading,
+    loading = 'lazy',
     width,
     ...props
 }: QueryImageProps) => {
     const image = getImage(data)
     if (data) {
         return (
-            <ImageWrapper width={width} height={height} className={className}>
+            <ImageWrapper loading={loading} width={width} height={height} className={className}>
                 <GatsbyImage image={image} alt={alt} loading={loading} {...props} />
             </ImageWrapper>
         )


### PR DESCRIPTION
Changes:
- By default, Gatsby Images will use the fade-in animation for image load
- Animations on appear like this impacts, LCP. This PR removes fade in animation on eager loaded images

## Type of change

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [x] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
