### PR TITLE
GTM event delay

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -177,7 +177,7 @@ export const onRouteUpdate = () => {
                 userId: client_information.user_id,
             }),
         })
-    }, 50)
+    }, 1500)
 }
 
 export const wrapPageElement = WrapPagesWithLocaleContext

--- a/src/components/layout/layout.js
+++ b/src/components/layout/layout.js
@@ -146,7 +146,11 @@ const Layout = ({
                 (!is_eu_country || tracking_status === 'accepted') && !gtm_data && has_dataLayer
 
             if (allow_tracking) {
-                setGTMData({ event: 'allow_tracking' })
+                window.onload = () => {
+                    window.setTimeout(() => {
+                        setGTMData({ event: 'allow_tracking' })
+                    }, 2000)
+                }
             }
             setMounted(true)
         }


### PR DESCRIPTION
Changes:

-  Added a delay to fire `page_view` events 
-  Added an onload listener to trigger `allow_tracking` events only after the window is loaded

## Type of change

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [x] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
