### PR TITLE
nikolai.berestevich/fix/crypto-icons

### DIFF
--- a/src/pages/markets/instruments/_market-symbols.js
+++ b/src/pages/markets/instruments/_market-symbols.js
@@ -698,40 +698,8 @@ export const cryptocurrencies_trade_type = [
         text: <Localize translate_text="Bitcoin" />,
     },
     {
-        src: icons.BCH,
-        text: <Localize translate_text="Bitcoin Cash" />,
-    },
-    {
         src: icons.ETH,
         text: <Localize translate_text="Ethereum" />,
-    },
-    {
-        src: icons.LTC,
-        text: <Localize translate_text="Litecoin" />,
-    },
-    {
-        src: icons.EOS,
-        text: <Localize translate_text="EOS" />,
-    },
-    {
-        src: icons.BNB,
-        text: <Localize translate_text="Binance Coin" />,
-    },
-    {
-        src: icons.DASH,
-        text: <Localize translate_text="DASH" />,
-    },
-    {
-        src: icons.XRP,
-        text: <Localize translate_text="Ripple" />,
-    },
-    {
-        src: icons.MNR,
-        text: <Localize translate_text="Monero" />,
-    },
-    {
-        src: icons.ZEC,
-        text: <Localize translate_text="ZCash" />,
     },
 ]
 


### PR DESCRIPTION
Changes:

- only ETH and Bitcoin on trade-types/multiplier/

## Type of change

-   [ ] Bug fix
-   [ ] New feature
-   [ x ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
