### PR TITLE
NJ/fix: fixed the localized link for non english in responsible page

### DIFF
--- a/src/pages/responsible/_securing-account.tsx
+++ b/src/pages/responsible/_securing-account.tsx
@@ -96,7 +96,10 @@ const SecureAccount = () => {
                                     components={[
                                         <LocalizedLinkText
                                             key={0}
-                                            to="https://app.deriv.com/account/two-factor-authentication"
+                                            type="deriv_app"
+                                            external="true"
+                                            rel="noopener noreferrer"
+                                            to="/account/two-factor-authentication"
                                             color="red"
                                             size={14}
                                             has_no_end_slash={true}


### PR DESCRIPTION
Changes:

-  Fixed the localized link for non english in responsible page

## Type of change

-   [X] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
