### PR TITLE
fix: missing options tab in synthetics market page

### DIFF
--- a/src/pages/markets/components/markets/_synthetic-indices.js
+++ b/src/pages/markets/components/markets/_synthetic-indices.js
@@ -17,7 +17,7 @@ const OtherMarkets = Loadable(() => import('../sections/_other-markets.js'))
 import { getCountryRule } from 'components/containers/visibility'
 
 const StockIndices = ({ simple_step_content }) => {
-    const { is_eu, is_not_eu, is_uk } = getCountryRule()
+    const { is_eu, is_non_eu, is_uk } = getCountryRule()
 
     if (is_uk) {
         navigate('/404/')
@@ -41,7 +41,7 @@ const StockIndices = ({ simple_step_content }) => {
             <AvailableTrades
                 CFDs={<CFDs market_content={is_eu ? synthetic_cfds_eu : synthetic_cfds} />}
                 DigitalOptions={
-                    is_not_eu && (
+                    is_non_eu && (
                         <DigitalOptions
                             market_name={localize('synthetic indices')}
                             options_list={synthetic_options}


### PR DESCRIPTION
Changes:

-   fix: missing options tab in synthetics market page

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
