### PR TITLE
fiona/ resize footer section for besquare in responsive mode

### DIFF
--- a/src/components/layout/besquare/style/footer.js
+++ b/src/components/layout/besquare/style/footer.js
@@ -14,7 +14,7 @@ export const Section = styled(SectionContainer)`
     padding: 0;
 `
 export const FooterSection = styled(Section)`
-    margin-bottom: ${(props) => props.is_eu_country && '7.3rem'};
+    margin-bottom: ${(props) => props.is_eu_country && '12.3rem'};
 `
 
 export const ContentContainer = styled(Container)`


### PR DESCRIPTION
Changes:

-   Adjusted _FooterSection_ padding to fix the cropped icons in responsive mode for EU region

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
