### PR TITLE
Aswathy/ Deriv P2P section in help-centre page is hidden for EU clients

### DIFF
--- a/src/pages/help-centre/index.tsx
+++ b/src/pages/help-centre/index.tsx
@@ -275,7 +275,8 @@ const HelpCentre = () => {
                                 {article.map((item, idx) => {
                                     if (
                                         is_eu_country &&
-                                        item.category.props.translate_text === 'Deriv X'
+                                        (item.category.props.translate_text === 'Deriv X' ||
+                                            item.category.props.translate_text === 'Deriv P2P')
                                     ) {
                                         return <React.Fragment key={idx}></React.Fragment>
                                     }


### PR DESCRIPTION
Changes:

-  Deriv P2P section in help-centre page is hidden for EU clients

## Type of change

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
