### PR TITLE
Allow email validation to accept hyphens after the alias

### DIFF
--- a/src/common/validation.js
+++ b/src/common/validation.js
@@ -1,7 +1,7 @@
 import { localize } from 'components/localization'
 
 const validation_regex = {
-    email: /^[a-zA-Z0-9_.+-]+@((?:[\w]+\.)+)([a-zA-Z]{2,63}$)/,
+    email: /^[^@]+@[^@]+\.[^@.]{2,}$/,
     url: /^[\w|\-|.]+$/,
     alphabetic: /^[a-zA-Z]+$/,
     number: /^\d+$/,


### PR DESCRIPTION
Changes:

-   Allow email validation to accept hyphens after the alias

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
