### PR TITLE
Aswathy/fix: removal of affiliate token from cookies

### DIFF
--- a/src/components/custom/signup.js
+++ b/src/components/custom/signup.js
@@ -91,9 +91,9 @@ const Signup = (props) => {
 
         if (!token) {
             Cookies.remove('affiliate_tracking')
-            cookies_value.utm_campaign = 'null' //passing null as the cookies takes the affiliates token value when signed up without affiliate token
-            cookies_value.utm_medium = 'null'
-            cookies_value.utm_source = 'null'
+            delete cookies_value.utm_campaign
+            delete cookies_value.utm_medium
+            cookies_value.utm_source = 'null' //passing null as the cookies takes the affiliates token value when signed up without affiliate token
         }
 
         return {

--- a/src/components/custom/signup.js
+++ b/src/components/custom/signup.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import { graphql, StaticQuery, navigate } from 'gatsby'
 import styled from 'styled-components'
 import Cookies from 'js-cookie'
-import { getLanguage, isChoosenLanguage } from '../../common/utility'
+import { getLanguage, isChoosenLanguage, queryParams } from '../../common/utility'
 import { getCookiesObject, getCookiesFields, getDataObjFromCookies } from 'common/cookies'
 import { Box } from 'components/containers'
 import Login from 'common/login'
@@ -89,6 +89,14 @@ const Signup = (props) => {
         const cookies = getCookiesFields()
         const cookies_objects = getCookiesObject(cookies)
         const cookies_value = getDataObjFromCookies(cookies_objects, cookies)
+        const token = queryParams.get('t')
+
+        if (token == null) {
+            Cookies.remove('affiliate_tracking')
+            cookies_value.utm_campaign = 'null'
+            cookies_value.utm_medium = 'null'
+            cookies_value.utm_source = 'null'
+        }
 
         return {
             verify_email: formatted_email,

--- a/src/components/custom/signup.js
+++ b/src/components/custom/signup.js
@@ -93,7 +93,7 @@ const Signup = (props) => {
 
         if (token == null) {
             Cookies.remove('affiliate_tracking')
-            cookies_value.utm_campaign = 'null'
+            cookies_value.utm_campaign = 'null' //passing null as the cookies takes the affiliates token value when signed up without affiliate token
             cookies_value.utm_medium = 'null'
             cookies_value.utm_source = 'null'
         }

--- a/src/components/custom/signup.js
+++ b/src/components/custom/signup.js
@@ -84,14 +84,12 @@ const Signup = (props) => {
     }
 
     const getVerifyEmailRequest = (formatted_email) => {
-        const affiliate_token = Cookies.getJSON('affiliate_tracking')
-
         const cookies = getCookiesFields()
         const cookies_objects = getCookiesObject(cookies)
         const cookies_value = getDataObjFromCookies(cookies_objects, cookies)
         const token = queryParams.get('t')
 
-        if (token == null) {
+        if (!token) {
             Cookies.remove('affiliate_tracking')
             cookies_value.utm_campaign = 'null' //passing null as the cookies takes the affiliates token value when signed up without affiliate token
             cookies_value.utm_medium = 'null'
@@ -102,7 +100,7 @@ const Signup = (props) => {
             verify_email: formatted_email,
             type: 'account_opening',
             url_parameters: {
-                ...(affiliate_token && { affiliate_token: affiliate_token }),
+                ...(token && { affiliate_token: token }),
                 ...(cookies_value && { ...cookies_value }),
             },
         }

--- a/src/components/custom/signup.js
+++ b/src/components/custom/signup.js
@@ -2,7 +2,6 @@ import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 import { graphql, StaticQuery, navigate } from 'gatsby'
 import styled from 'styled-components'
-import Cookies from 'js-cookie'
 import { getLanguage, isChoosenLanguage, queryParams } from '../../common/utility'
 import { getCookiesObject, getCookiesFields, getDataObjFromCookies } from 'common/cookies'
 import { Box } from 'components/containers'
@@ -90,7 +89,6 @@ const Signup = (props) => {
         const token = queryParams.get('t')
 
         if (!token) {
-            Cookies.remove('affiliate_tracking')
             delete cookies_value.utm_campaign
             delete cookies_value.utm_medium
             cookies_value.utm_source = 'null' //passing null as the cookies takes the affiliates token value when signed up without affiliate token


### PR DESCRIPTION
Changes:

-   Removed the affiliate token from cookies during signup without affiliate token

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
