### PR TITLE
Meenu/fix: alignment fix in about us page

### DIFF
--- a/src/pages/partners/affiliate-ib/_dmt5-cards.tsx
+++ b/src/pages/partners/affiliate-ib/_dmt5-cards.tsx
@@ -114,6 +114,7 @@ const AccordionWrapper = styled.div`
 const TableWrapper = styled(Table)`
     margin: 0 auto 1.6rem;
     grid-auto-rows: 1fr;
+    grid-template-columns: 60% 40%;
 `
 const StyledTrap = styled(TRAP)<CardProps>`
     height: ${(props) => (props.headerHeight ? props.headerHeight : '')};


### PR DESCRIPTION
Changes:
Fixed Alignment issue in Volatility Indices list under Deriv MT5 Synthetics(About us-->Partnership Programmes-->Affiliates and IBs-->Deriv MT5 Synthetics-->Volatility indices) in Mobile devices
-   ...

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
