### PR TITLE
Meenu/ fix: localize the text markets in homepage

### DIFF
--- a/src/pages/home/_markets_fold.tsx
+++ b/src/pages/home/_markets_fold.tsx
@@ -371,7 +371,7 @@ const MarketsFold = () => {
             <FoldContainer direction="column">
                 <Flex width="100%" jc="center">
                     <Header type="heading-1" align="center" mb="40px" tablet={{ mb: '24px' }}>
-                        Markets
+                        <Localize translate_text="Markets" />
                     </Header>
                 </Flex>
                 <Carousel


### PR DESCRIPTION
Changes:

Localize text "Markets" in homepage

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [x] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
