### PR TITLE
Fix multicore build

### DIFF
--- a/src/pages/academy/components/video-banner/_VideoCarousel.tsx
+++ b/src/pages/academy/components/video-banner/_VideoCarousel.tsx
@@ -150,7 +150,6 @@ const VideoCarousel = ({ carousel_items }: VideoCarouselProps) => {
                                         <GatsbyImage
                                             image={
                                                 item.video_thumbnail.imageFile.childImageSharp
-                                                    .gatsbyImageData
                                             }
                                             alt={thumbnail_img_alt}
                                             width="100%"


### PR DESCRIPTION
## Change
Fix multi-core build. 

In addition to a green build when forgetting the `GATSBY_CPU_COUNT`, it allows a speed up the build (from 12min to less than 7min on my local computer 8 cores)

## Background
For months (I think) the [multi-core build](https://www.gatsbyjs.com/docs/multi-core-builds/) is broken and the number of CPU has to be [forced](https://github.com/binary-com/deriv-com/commit/52b73512cf254d3b4abe28bc4f67d8a0a266a066#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R98) on multi-core machines with `GATSBY_CPU_COUNT=2` (which translates to single core since Gatsby does "number of cores - 1" see [gatsby-node.js](https://github.com/gatsbyjs/gatsby/blob/e7afa54e99dcc176eb22a7becd425c6ec28a3c8c/benchmarks/memory/gatsby-node.js#L145))

The error message reported when a build is failing because of multi-core is very misleading:
```
WebpackError: TypeError: Cannot read property 'gatsbyImageData' of null
```

## Caution
I'm definitely not a front end dev hence if it has a positive impact on build I don't know it is meaningful or has a bad impact on overall generated website. Could someone please carefully review this change? (tell me if it's and obvious bad change or execute and check generated images/pages or assist me in doing this)

## Type of change

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [x] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
