### PR TITLE
Meenu/ fix: added comma before and in EU and UK

### DIFF
--- a/src/pages/markets/components/sections/_hero.tsx
+++ b/src/pages/markets/components/sections/_hero.tsx
@@ -90,10 +90,10 @@ export const Hero = () => {
                     mt="1.6rem"
                 >
                     <EU>
-                        <Localize translate_text="Learn about the markets that you can trade online with Deriv, including forex, synthetic indices, stocks & indices, cryptocurrencies and commodities." />
+                        <Localize translate_text="Learn about the markets that you can trade online with Deriv, including forex, synthetic indices, stocks & indices, cryptocurrencies, and commodities." />
                     </EU>
                     <UK>
-                        <Localize translate_text="Learn about the markets that you can trade online with Deriv, including forex, stocks & indices and commodities." />
+                        <Localize translate_text="Learn about the markets that you can trade online with Deriv, including forex, stocks & indices, and commodities." />
                     </UK>
                     <ROW>
                         <Localize translate_text=" Learn about the markets that you can trade online with Deriv, including forex, synthetic indices, stocks & indices, cryptocurrencies, basket indices, and commodities." />


### PR DESCRIPTION
Changes:
Added comma before commodities in market description for EU and UK clients
-   ...

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
