### PR TITLE
Mohsen / removed gatsby markets redirect

### DIFF
--- a/deriv.com.conf
+++ b/deriv.com.conf
@@ -61,8 +61,8 @@ server {
         return 301 https://$http_host/careers/besquare/;
     }
     
-    location ~* "^/([\w]{0,2}|zh-tw|zh-cn)/markets?/$" {
-        return 301 $scheme://$http_host/$1/markets/forex/;
+    location ~* "^(/[\w]{0,2}|zh-tw|zh-cn)?/markets/?$" {
+        return 301 $scheme://$http_host$1/markets/forex/;
     }
     
     location /page-data {

--- a/deriv.com.conf
+++ b/deriv.com.conf
@@ -60,9 +60,9 @@ server {
     location /besquare {
         return 301 https://$http_host/careers/besquare/;
     }
-
-    location ~* "^/([\w]{0,2}|zh-tw|zh-cn)/markets" {
-        return 301 https://$http_host/$1/markets/forex/;
+    
+    location ~* "^/([\w]{0,2}|zh-tw|zh-cn)/markets?/$" {
+        return 301 $scheme://$http_host/$1/markets/forex/;
     }
     
     location /page-data {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -14,7 +14,6 @@ exports.onCreatePage = ({ page, actions }) => {
     const is_contact_us = /contact_us/g.test(page.path)
     const is_p2p = /responsible/g.test(page.path)
     const who_we_are = /who-we-are/g.test(page.path)
-    const is_market = /markets/g.test(page.path)
     const is_cfds = /cfds/g.test(page.path)
 
     if (is_responsible_trading) {
@@ -102,21 +101,6 @@ exports.onCreatePage = ({ page, actions }) => {
         createRedirect({
             fromPath: `/leadership`,
             toPath: `/who-we-are/`,
-            redirectInBrowser: true,
-            isPermanent: true,
-        })
-    }
-
-    if (is_market) {
-        createRedirect({
-            fromPath: `/markets/`,
-            toPath: `/markets/forex/`,
-            redirectInBrowser: true,
-            isPermanent: true,
-        })
-        createRedirect({
-            fromPath: `/markets`,
-            toPath: `/markets/forex/`,
             redirectInBrowser: true,
             isPermanent: true,
         })
@@ -270,21 +254,6 @@ exports.onCreatePage = ({ page, actions }) => {
             createRedirect({
                 fromPath: `/${lang}/leadership`,
                 toPath: `/${lang}/who-we-are/`,
-                redirectInBrowser: true,
-                isPermanent: true,
-            })
-        }
-
-        if (is_market) {
-            createRedirect({
-                fromPath: `/${lang}/markets/`,
-                toPath: `/${lang}/markets/forex/`,
-                redirectInBrowser: true,
-                isPermanent: true,
-            })
-            createRedirect({
-                fromPath: `/${lang}/markets`,
-                toPath: `/${lang}/markets/forex/`,
                 redirectInBrowser: true,
                 isPermanent: true,
             })


### PR DESCRIPTION
Changes:
- since we added redirects in nginx conf, these should be removed
- changes on this PR won't be testable on vercel test link, and it's only testable on staging deployment.

### How to test this
1. cd into root of the project.
2. build the docker image like so:
```
docker build -t deriv-redirect . 
```
3. run the docker container like so: 
```
docker run -p 80:80 deriv-redirect
```
4. open up localhost on browser.
5. go to [localhost/markets](localhost/markets) ===> it should redirect you to [localhost/markets/forex/](localhost/markets/forex/)
6. go to [localhost/pt/markets](localhost/pt/markets) ===> it should redirect you to [localhost/pt/markets/forex/](localhost/pt/markets/forex/)
7. go to [localhost/pt/markets/stock](localhost/pt/markets/stock) ===> it should redirect you to [localhost/pt/markets/stock](localhost/pt/markets/stock)

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
