### PR TITLE
tib/chore: setup node v3 with cache

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -24,17 +24,11 @@ jobs:
               uses: actions/checkout@v2.3.1
 
             - name: Set up Node.js
-              uses: actions/setup-node@v1
+              uses: actions/setup-node@v3
               with:
                   node-version: 14
-            - name: Cache dependencies
-              id: cache
-              uses: actions/cache@v2
-              env:
-                  cache-name: cache-node-modules
-              with:
-                  path: ./node_modules
-                  key: modules-${{ hashFiles('package-lock.json') }}
+                  cache: 'npm'
+
             - name: Install Node.js dependencies
               run: |
                   npm ci
@@ -50,20 +44,13 @@ jobs:
               uses: actions/checkout@v2.3.1
 
             - name: Setup Node
-              uses: actions/setup-node@v2.1.2
+              uses: actions/setup-node@v3
               with:
                   node-version: '14.x'
+                  cache: 'npm'
 
             - name: Set version env variable
               run: echo "GATSBY_DERIV_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-
-            - name: Cache dependencies
-              uses: actions/cache@v2
-              with:
-                  path: ~/.npm
-                  key: ${{ runner.os }}-node-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/package-lock.json') }}
-                  restore-keys: |
-                      ${{ runner.os }}-node-${{ secrets.CACHE_VERSION }}
 
             - name: Cache Gatsby
               id: gatsby-cache-build

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -29,17 +29,11 @@ jobs:
               uses: actions/checkout@v2.3.1
 
             - name: Set up Node.js
-              uses: actions/setup-node@v1
+              uses: actions/setup-node@v3
               with:
                   node-version: 14
-            - name: Cache dependencies
-              id: cache
-              uses: actions/cache@v2
-              env:
-                  cache-name: cache-node-modules
-              with:
-                  path: ./node_modules
-                  key: modules-${{ hashFiles('package-lock.json') }}
+                  cache: 'npm'
+
             - name: Install Node.js dependencies
               run: |
                   npm ci
@@ -55,17 +49,10 @@ jobs:
               uses: actions/checkout@v2.3.1
 
             - name: Setup Node
-              uses: actions/setup-node@v2.1.2
+              uses: actions/setup-node@v3
               with:
                   node-version: '14.x'
-
-            - name: Cache dependencies
-              uses: actions/cache@v2
-              with:
-                  path: ~/.npm
-                  key: ${{ runner.os }}-node-${{ secrets.CACHE_VERSION }}-${{ hashFiles('/package-lock.json') }}
-                  restore-keys: |
-                      ${{ runner.os }}-node-${{ secrets.CACHE_VERSION }}
+                  cache: 'npm'
 
             - name: Cache Gatsby
               id: gatsby-cache-build


### PR DESCRIPTION
Changes:

-   Use v3 of actions/setup-node and its native caching capability

## Type of change

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [x] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
