### PR TITLE
empty: order tags numerically instead using commit date

### DIFF
--- a/.github/workflows/content.yml
+++ b/.github/workflows/content.yml
@@ -49,7 +49,7 @@ jobs:
               id: get_tag_name
               run: |
                    git fetch --prune --unshallow --tags
-                   GIT_TAG_NAME=`git tag --format='%(creatordate:short)%09%(refname:strip=2)' --sort=creatordate | grep production | awk '{ print $2; }' | tail -1`
+                   GIT_TAG_NAME=`git tag -l | grep production | sort -V | tail -1`
                    
                    echo "git tag is ${GIT_TAG_NAME}"
                    echo ::set-output name=VERSION::${GIT_TAG_NAME}

--- a/.github/workflows/content.yml
+++ b/.github/workflows/content.yml
@@ -49,7 +49,7 @@ jobs:
               id: get_tag_name
               run: |
                    git fetch --prune --unshallow --tags
-                   GIT_TAG_NAME=`git tag -l | grep production | sort -V | tail -1`
+                   GIT_TAG_NAME=`git tag -l | grep production_V | sort -V | tail -1`
                    
                    echo "git tag is ${GIT_TAG_NAME}"
                    echo ::set-output name=VERSION::${GIT_TAG_NAME}


### PR DESCRIPTION
:warning: DO NOT MERGE 
- [ ] First clean problematic tags `production_V202001001_0` and `production_v20200401` (not respecting naming conventions)

Changes:
-   Retrieve latest tag by sorting version instead of looking at commit date

Notes:
- Another solution would be to use *annotated tags* when tagging and then sort on *taggerdate*

## Type of change

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [x] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
