### PR TITLE
chore: added .dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+*
+!public/*
+!deriv.com.conf


### PR DESCRIPTION
Changes:
- right now when building the docker image, docker has to copy ~5GB of
content to build context, with this it will be around ~900mb so it will
help with faster build times on staging and production

Steps:
- checkout the project
- run `docker build -t test-deriv-com .`
- the build context will be ~900 MB, currently its around ~5GB.

## Type of change

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
