### PR TITLE
Mohsen / : fixed i18next-react Trans import type error

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,7 +9,7 @@
     ],
     "overrides": [
         {
-            "files": ["*.{ts,tsx}"],
+            "files": ["*.ts", "*.tsx"], // Your TypeScript files extension
             "parser": "@typescript-eslint/parser",
             "extends": [
                 "eslint:recommended",

--- a/src/components/containers/box.tsx
+++ b/src/components/containers/box.tsx
@@ -84,7 +84,7 @@ export type BoxType = {
     bg?: string
 }
 
-const Box = styled.div<BoxType>`
+const Box = styled.div<BoxType & BaseStyleType>`
     width: ${(props) => (props.width ? props.width : '')};
     height: ${(props) => (props.height ? props.height : '')};
     min-height: ${(props) => (props.min_height ? props.min_height : '')};

--- a/src/components/localization/localize.tsx
+++ b/src/components/localization/localize.tsx
@@ -2,9 +2,9 @@ import React from 'react'
 import { Trans } from 'react-i18next'
 
 type LocalizeProps = {
-    translate_text: string | JSX.Element
+    translate_text: string
     values?: { email?: string }
-    components?: React.ReactNode[]
+    components?: React.ReactElement[]
 }
 
 export const Localize = ({ translate_text, values, components }: LocalizeProps) => (

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-    "include": ["./src/**/*", "./src/custom.d.ts"],
+    "include": ["./src/**/*", "./src/custom.d.ts", "types/react-i18next.d.ts"],
     "jsx": "react",
     "compilerOptions": {
         "baseUrl": "src",

--- a/types/react-i18next.d.ts
+++ b/types/react-i18next.d.ts
@@ -1,4 +1,4 @@
-import { resources, defaultNS } from './components/localization/config'
+import { resources, defaultNS } from '../src/components/localization/config'
 
 declare module 'react-i18next' {
     interface CustomTypeOptions {


### PR DESCRIPTION
Changes:

-  Fixed the type eslint issue with `i18next-react` issue, this is related to `tsconfig.json` and `eslintrc`

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
