### PR TITLE
Ako/ improve subdomain matcher to match exact eu and uk words

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -36,17 +36,17 @@ const getDomainAppID = () => {
     else return deriv_com_app_id
 }
 // '-eu__testlink' and '-uk__testlink' regexes are meant to create test links for eu and uk countries.
-// To make them work on your test links you need to end your branch name with `'-eu__testlink' and '-uk__testlink'
+// To make them work on your test links you need to start your branch name with `'eu__testlink-' and 'uk__testlink-'
 export const eu_domains = [
     new RegExp(/^eu$/),
     new RegExp(/^staging-eu$/),
-    new RegExp(/-eu__testlink$/),
+    new RegExp(/^eu__testlink-/),
 ]
 export const eu_urls = ['eu.deriv.com', 'staging-eu.deriv.com']
 export const uk_domains = [
     new RegExp(/^uk$/),
     new RegExp(/^staging-uk$/),
-    new RegExp(/-uk__testlink$/),
+    new RegExp(/uk__testlink-/),
 ]
 
 // URL

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -36,7 +36,7 @@ const getDomainAppID = () => {
     else return deriv_com_app_id
 }
 // '-eu__testlink-' and '-uk__testlink-' regexes are meant to create test links for eu and uk countries.
-// To make them work on your test links you need to start your branch name with '-eu__testlink-' and '-uk__testlink-'
+// To make them work on your test links you need to include '-eu__testlink-' or '-uk__testlink-' in your branch name.
 export const eu_domains = [
     new RegExp(/^eu$/),
     new RegExp(/^staging-eu$/),

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -40,13 +40,13 @@ const getDomainAppID = () => {
 export const eu_domains = [
     new RegExp(/^eu$/),
     new RegExp(/^staging-eu$/),
-    new RegExp(/^eu__testlink-/),
+    new RegExp(/-eu__testlink-/),
 ]
 export const eu_urls = ['eu.deriv.com', 'staging-eu.deriv.com']
 export const uk_domains = [
     new RegExp(/^uk$/),
     new RegExp(/^staging-uk$/),
-    new RegExp(/uk__testlink-/),
+    new RegExp(/-uk__testlink-/),
 ]
 
 // URL

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -35,10 +35,19 @@ const getDomainAppID = () => {
     else if (getDomainUrl() === deriv_be_url) return deriv_be_app_id
     else return deriv_com_app_id
 }
-
-export const eu_domains = ['eu', 'staging-eu']
+// '-eu__testlink' and '-uk__testlink' regexes are meant to create test links for eu and uk countries.
+// To make them work on your test links you need to end your branch name with `'-eu__testlink' and '-uk__testlink'
+export const eu_domains = [
+    new RegExp(/^eu$/),
+    new RegExp(/^staging-eu$/),
+    new RegExp(/-eu__testlink$/),
+]
 export const eu_urls = ['eu.deriv.com', 'staging-eu.deriv.com']
-export const uk_domains = ['uk', 'staging-uk']
+export const uk_domains = [
+    new RegExp(/^uk$/),
+    new RegExp(/^staging-uk$/),
+    new RegExp(/-uk__testlink$/),
+]
 
 // URL
 export const domain_full_url = `https://${getDomainUrl()}`

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -35,8 +35,8 @@ const getDomainAppID = () => {
     else if (getDomainUrl() === deriv_be_url) return deriv_be_app_id
     else return deriv_com_app_id
 }
-// '-eu__testlink' and '-uk__testlink' regexes are meant to create test links for eu and uk countries.
-// To make them work on your test links you need to start your branch name with `'eu__testlink-' and 'uk__testlink-'
+// '-eu__testlink-' and '-uk__testlink-' regexes are meant to create test links for eu and uk countries.
+// To make them work on your test links you need to start your branch name with '-eu__testlink-' and '-uk__testlink-'
 export const eu_domains = [
     new RegExp(/^eu$/),
     new RegExp(/^staging-eu$/),

--- a/src/common/utility.js
+++ b/src/common/utility.js
@@ -458,9 +458,9 @@ export const handleDerivRedirect = (country, subdomain) => {
 
 const getSubdomain = () => isBrowser() && window.location.hostname.split('.')[0]
 
-export const isEuDomain = () => !!eu_domains.some((e) => getSubdomain().includes(e))
+export const isEuDomain = () => !!eu_domains.some((e) => e.test(getSubdomain()))
 
-export const isUkDomain = () => !!uk_domains.some((e) => getSubdomain().includes(e))
+export const isUkDomain = () => !!uk_domains.some((e) => e.test(getSubdomain()))
 
 export const handleRedirect = (residence, current_client_country) => {
     const country = residence ? residence : current_client_country

--- a/src/common/utility.js
+++ b/src/common/utility.js
@@ -458,9 +458,11 @@ export const handleDerivRedirect = (country, subdomain) => {
 
 const getSubdomain = () => isBrowser() && window.location.hostname.split('.')[0]
 
-export const isEuDomain = () => !!eu_domains.some((e) => e.test(getSubdomain()))
+export const isEuDomain = () =>
+    !!eu_domains.some((eu_sub_domain) => eu_sub_domain.test(getSubdomain()))
 
-export const isUkDomain = () => !!uk_domains.some((e) => e.test(getSubdomain()))
+export const isUkDomain = () =>
+    !!uk_domains.some((uk_sub_domain) => uk_sub_domain.test(getSubdomain()))
 
 export const handleRedirect = (residence, current_client_country) => {
     const country = residence ? residence : current_client_country


### PR DESCRIPTION
Changes:

-   Changed the eu and uk domain arrays to regex to test them over subdomain
-  Improved eu and uk matcher functions to test the regexes instead of check if they are included the strings.
-  To have the test links for an specific sub-domain your branch name should contains `-uk__testlink-` or `-eu__testlink-`, best if add to the start of branch name .
## Type of change

-   [x] Bug fix
-   [x] New feature
-   [x] Update feature
-   [x] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
