### PR TITLE
Eduard / Attribute loading not allowed on element div (loading isn't an attribute, it's a props)

### DIFF
--- a/src/components/elements/query-image.tsx
+++ b/src/components/elements/query-image.tsx
@@ -1,26 +1,17 @@
-import React, { CSSProperties, MouseEventHandler, ReactElement } from 'react'
+import React, { CSSProperties, ReactElement } from 'react'
 import styled from 'styled-components'
 import { GatsbyImage, getImage } from 'gatsby-plugin-image'
 import type { ImageDataLike, IGatsbyImageData, GatsbyImageProps } from 'gatsby-plugin-image'
 
-type CustomOmit = Omit<
-    GatsbyImageProps,
-    'width' | 'height' | 'className' | 'style' | 'onMouseOver' | 'onMouseOut' | 'onClick'
->
-
 export type QueryImageProps = {
     alt: ReactElement | string
-    className?: string
     data: ImageDataLike | IGatsbyImageData
     height?: string
     width?: string
     max_width?: string
     loading?: 'eager' | 'lazy'
-    onMouseOver?: MouseEventHandler<HTMLDivElement>
-    onMouseOut?: MouseEventHandler<HTMLDivElement>
-    onClick?: MouseEventHandler<HTMLDivElement>
     style?: CSSProperties
-} & CustomOmit
+} & Omit<GatsbyImageProps, 'width' | 'height' | 'alt' | 'image'>
 
 export type ImageWrapperProps = {
     width: string

--- a/src/components/elements/query-image.tsx
+++ b/src/components/elements/query-image.tsx
@@ -1,7 +1,12 @@
 import React, { CSSProperties, MouseEventHandler, ReactElement } from 'react'
 import styled from 'styled-components'
 import { GatsbyImage, getImage } from 'gatsby-plugin-image'
-import type { ImageDataLike, IGatsbyImageData } from 'gatsby-plugin-image'
+import type { ImageDataLike, IGatsbyImageData, GatsbyImageProps } from 'gatsby-plugin-image'
+
+type CustomOmit = Omit<
+    GatsbyImageProps,
+    'width' | 'height' | 'className' | 'style' | 'onMouseOver' | 'onMouseOut' | 'onClick'
+>
 
 export type QueryImageProps = {
     alt: ReactElement | string
@@ -15,7 +20,7 @@ export type QueryImageProps = {
     onMouseOut?: MouseEventHandler<HTMLDivElement>
     onClick?: MouseEventHandler<HTMLDivElement>
     style?: CSSProperties
-}
+} & CustomOmit
 
 export type ImageWrapperProps = {
     width: string
@@ -43,12 +48,7 @@ const QueryImage = ({
     const image = getImage(data)
     if (data) {
         return (
-            <ImageWrapper
-                width={width}
-                height={height}
-                className={className}
-                onClick={onClick}
-            >
+            <ImageWrapper width={width} height={height} className={className} onClick={onClick}>
                 <GatsbyImage image={image} alt={alt as string} loading={loading} {...props} />
             </ImageWrapper>
         )

--- a/src/components/elements/query-image.tsx
+++ b/src/components/elements/query-image.tsx
@@ -1,5 +1,5 @@
 import React, { CSSProperties, MouseEventHandler, ReactElement } from 'react'
-import styled, { css } from 'styled-components'
+import styled from 'styled-components'
 import { GatsbyImage, getImage } from 'gatsby-plugin-image'
 import type { ImageDataLike, IGatsbyImageData } from 'gatsby-plugin-image'
 
@@ -11,7 +11,6 @@ export type QueryImageProps = {
     width?: string
     max_width?: string
     loading?: 'eager' | 'lazy'
-    disable_transition?: boolean
     onMouseOver?: MouseEventHandler<HTMLDivElement>
     onMouseOut?: MouseEventHandler<HTMLDivElement>
     onClick?: MouseEventHandler<HTMLDivElement>
@@ -22,8 +21,6 @@ export type ImageWrapperProps = {
     width: string
     height: string
     className?: string
-    loading: 'eager' | 'lazy'
-    disable_transition?: boolean
 }
 
 export const ImageWrapper = styled.div<ImageWrapperProps>`
@@ -31,23 +28,12 @@ export const ImageWrapper = styled.div<ImageWrapperProps>`
         width: ${(props) => props.width || '100%'};
         height: ${(props) => props.height};
     }
-    .gatsby-image-wrapper [data-main-image] {
-        ${({ loading, disable_transition }) => {
-            if (disable_transition && loading === 'eager') {
-                return css`
-                    transition: none;
-                    opacity: 1;
-                `
-            }
-        }}
-    }
 `
 
 const QueryImage = ({
     alt,
     className,
     data,
-    disable_transition = false,
     height,
     loading = 'lazy',
     onClick,
@@ -58,11 +44,9 @@ const QueryImage = ({
     if (data) {
         return (
             <ImageWrapper
-                loading={loading}
                 width={width}
                 height={height}
                 className={className}
-                disable_transition={disable_transition}
                 onClick={onClick}
             >
                 <GatsbyImage image={image} alt={alt as string} loading={loading} {...props} />


### PR DESCRIPTION
Changes:

-   removed unused code in ImageWrapper (never changes `disable_transition` props value to `true`, always uses default `disable_transition` props value, `loading` value changes due to `[data-main-image]`. Both conditions must be met, but this behavior will never happen)

## Type of change

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ X ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
