### PR TITLE
Mitra/change `silver/eur` to `silver/usd` in commodities option tab

### DIFF
--- a/src/pages/markets/static/content/_digital-options.tsx
+++ b/src/pages/markets/static/content/_digital-options.tsx
@@ -240,7 +240,7 @@ export const commodities_options: Options = {
             },
         ],
         markets_list: {
-            col: 4,
+            col: 3,
         },
     },
     options: getOptions(false),

--- a/src/pages/markets/static/content/_digital-options.tsx
+++ b/src/pages/markets/static/content/_digital-options.tsx
@@ -241,6 +241,7 @@ export const commodities_options: Options = {
         ],
         markets_list: {
             col: 3,
+            mobile_col: 2,
         },
     },
     options: getOptions(false),

--- a/src/pages/markets/static/content/_market-symbols.tsx
+++ b/src/pages/markets/static/content/_market-symbols.tsx
@@ -438,7 +438,7 @@ export const metals_options: MarketSymbol[] = [
     },
     {
         src: icons.SILVEREUR,
-        text: <Localize translate_text="Silver/EUR" />,
+        text: <Localize translate_text="Silver/USD" />,
     },
 ]
 


### PR DESCRIPTION
Changes:

-   ...

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
