### PR TITLE
remove strategy option from gatsby-google-gtm

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -19,7 +19,6 @@ module.exports = {
         siteUrl: site_url,
     },
     partytownProxiedURLs: [
-        `https://www.googletagmanager.com/gtm.js?id=GTM-NF7884S`,
         `https://assets.customer.io/assets/track-eu.js`,
         `https://assets.customer.io/assets/track.js`,
         `https://static.deriv.com/scripts/cookie.js`,
@@ -221,7 +220,6 @@ module.exports = {
             options: {
                 id: 'GTM-NF7884S',
                 includeInDevelopment: false,
-                strategy: 'off-main-thread',
             },
         },
         {


### PR DESCRIPTION
Changes:

-   remove strategy option from gatsby-google-gtm

## Type of change

-   [ X ] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
