### PR TITLE
Specify GITHUB_TOKEN permissions in lighthouse.yml

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,5 +1,13 @@
 name: Deriv Lighthouse Audit
 
+permissions:
+  actions: write
+  checks: write
+  contents: write
+  deployments: write
+  pull-requests: write
+  statuses: write
+
 on:
     issue_comment:
         types: [edited]


### PR DESCRIPTION
Changes:
-   Give back some permission to GITHUB_TOKEN

## Type of change

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [x] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
