### PR TITLE
MohammadH/ Remove gatsby-plugin-page-progress

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,6 @@
                 "gatsby-plugin-google-tagmanager": "^4.14.0",
                 "gatsby-plugin-image": "2.19.0",
                 "gatsby-plugin-manifest": "^4.14.0",
-                "gatsby-plugin-page-progress": "^2.2.1",
                 "gatsby-plugin-react-helmet": "^5.16.0",
                 "gatsby-plugin-react-helmet-canonical-urls": "^1.4.0",
                 "gatsby-plugin-robots-txt": "^1.7.1",
@@ -25726,11 +25725,6 @@
             "peerDependencies": {
                 "gatsby": "^4.0.0-next"
             }
-        },
-        "node_modules/gatsby-plugin-page-progress": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/gatsby-plugin-page-progress/-/gatsby-plugin-page-progress-2.2.1.tgz",
-            "integrity": "sha512-ItrUyMQOyhMjtEsJ+IKQVKNJ7qa+8E4P16mQSPd1fsxTUcmEn5vNT47pCVnePjT5MuxarFRTbvy1mcHARgp0ew=="
         },
         "node_modules/gatsby-plugin-react-helmet": {
             "version": "5.22.0",
@@ -66133,11 +66127,6 @@
                 "globby": "^11.1.0",
                 "lodash": "^4.17.21"
             }
-        },
-        "gatsby-plugin-page-progress": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/gatsby-plugin-page-progress/-/gatsby-plugin-page-progress-2.2.1.tgz",
-            "integrity": "sha512-ItrUyMQOyhMjtEsJ+IKQVKNJ7qa+8E4P16mQSPd1fsxTUcmEn5vNT47pCVnePjT5MuxarFRTbvy1mcHARgp0ew=="
         },
         "gatsby-plugin-react-helmet": {
             "version": "5.22.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
         "gatsby-plugin-google-tagmanager": "^4.14.0",
         "gatsby-plugin-image": "2.19.0",
         "gatsby-plugin-manifest": "^4.14.0",
-        "gatsby-plugin-page-progress": "^2.2.1",
         "gatsby-plugin-react-helmet": "^5.16.0",
         "gatsby-plugin-react-helmet-canonical-urls": "^1.4.0",
         "gatsby-plugin-robots-txt": "^1.7.1",


### PR DESCRIPTION
Changes:

-   This plugin has not been used after removing Academy from deriv-com project

## Type of change

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
