### PR TITLE
Ako/ change datadog sampleRate to 1%

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -328,7 +328,7 @@ module.exports = {
             resolve: 'gatsby-plugin-datadog',
             options: {
                 site: 'datadoghq.com',
-                sampleRate: 100,
+                sampleRate: 1,
                 replaySampleRate: 20,
                 enabled: true,
                 env: 'production',


### PR DESCRIPTION
Changes:

-   revert back datadog sampleRate to 1%

## Type of change

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
