### PR TITLE
Ako/ change sampleRate key to sessionSampleRate

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -328,7 +328,7 @@ module.exports = {
             resolve: 'gatsby-plugin-datadog',
             options: {
                 site: 'datadoghq.com',
-                sampleRate: 1,
+                sessionSampleRate: 100,
                 replaySampleRate: 20,
                 enabled: true,
                 env: 'production',


### PR DESCRIPTION

Changes:

-   sessionSampleRate used instead of sampleRate because sampleRate is deprecated

## Type of change

-   [ ] Bug fix
-   [ ] New feature
-   [x] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
