### PR TITLE
chore: added stale PR github action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,24 @@
+permissions:
+    issues: write
+    pull-requests: write
+
+name: 'Close stale issues and PRs'
+on:
+    workflow_dispatch:
+    schedule:
+        - cron: '30 1 * * *'
+
+jobs:
+    stale:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/stale@v8
+              with:
+                  stale-issue-message: 'This issue is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
+                  stale-pr-message: 'This PR is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
+                  close-issue-message: 'This issue was closed because it has been stalled for 5 days with no activity. Please reopen it if needed.'
+                  close-pr-message: 'This PR was closed because it has been stalled for 5 days with no activity. Please reopen it if needed.'
+                  days-before-stale: 60
+                  days-before-close: 5
+                  ascending: true
+                  operations-per-run: 200


### PR DESCRIPTION
Changes:

-  add stale label to PRs after 60 days of inactivity
-  close stale PRs after 5 days 

## Type of change

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [x] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
