### PR TITLE
Optimize build time by selecting less formats for image fallback

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -71,14 +71,26 @@ module.exports = {
             },
         },
         'gatsby-transformer-sharp',
-        {
-            resolve: `gatsby-plugin-sharp`,
-            options: {
-                failOnError: true,
-                base64Width: 20,
-                stripMetadata: true,
-                defaultQuality: 50,
-            },
+	{
+          resolve: `gatsby-plugin-sharp`,
+          options: {
+	    failOnError: true,
+            base64Width: 20,
+            stripMetadata: true,
+            defaultQuality: 50,
+            defaults: {
+              formats: [`webp`],
+              placeholder: `dominantColor`,
+              quality: 50,
+              backgroundColor: `transparent`,
+              tracedSVGOptions: {},
+              blurredOptions: {},
+              jpgOptions: {},
+              pngOptions: {},
+              webpOptions: {},
+              avifOptions: {},
+            }
+          }
         },
         `gatsby-plugin-image`,
         {

--- a/src/components/graphql/image-fragments.ts
+++ b/src/components/graphql/image-fragments.ts
@@ -5,11 +5,7 @@ import { graphql } from 'gatsby'
 export const heroImage = graphql`
     fragment heroImage on File {
         childImageSharp {
-            gatsbyImageData(
-                formats: [AUTO, AVIF, WEBP]
-                layout: FULL_WIDTH
-                placeholder: DOMINANT_COLOR
-            )
+            gatsbyImageData(formats: [AVIF, WEBP], layout: FULL_WIDTH, placeholder: DOMINANT_COLOR)
         }
     }
 `
@@ -17,12 +13,7 @@ export const heroImage = graphql`
 export const backgroundImage = graphql`
     fragment backgroundImage on File {
         childImageSharp {
-            gatsbyImageData(
-                formats: [AUTO, WEBP]
-                layout: CONSTRAINED
-                quality: 100
-                placeholder: NONE
-            )
+            gatsbyImageData(layout: CONSTRAINED, quality: 100, placeholder: NONE)
         }
     }
 `
@@ -30,7 +21,7 @@ export const backgroundImage = graphql`
 export const bannerImage = graphql`
     fragment bannerImage on File {
         childImageSharp {
-            gatsbyImageData(formats: [AUTO, AVIF, WEBP], layout: CONSTRAINED, placeholder: NONE)
+            gatsbyImageData(formats: [AVIF, WEBP], layout: CONSTRAINED, placeholder: NONE)
         }
     }
 `
@@ -38,12 +29,7 @@ export const bannerImage = graphql`
 export const fadeIn = graphql`
     fragment fadeIn on File {
         childImageSharp {
-            gatsbyImageData(
-                formats: [AUTO, WEBP]
-                layout: CONSTRAINED
-                breakpoints: [360, 992]
-                placeholder: NONE
-            )
+            gatsbyImageData(layout: CONSTRAINED, breakpoints: [360, 992], placeholder: NONE)
         }
     }
 `
@@ -51,7 +37,7 @@ export const fadeIn = graphql`
 export const homePageHeroFadeIn = graphql`
     fragment homePageHeroFadeIn on File {
         childImageSharp {
-            gatsbyImageData(formats: [AUTO, AVIF, WEBP], layout: CONSTRAINED, placeholder: NONE)
+            gatsbyImageData(formats: [AVIF, WEBP], layout: CONSTRAINED, placeholder: NONE)
         }
     }
 `

--- a/src/features/components/templates/signup/with-banner/banner/index.tsx
+++ b/src/features/components/templates/signup/with-banner/banner/index.tsx
@@ -23,7 +23,7 @@ const PublicSignupBanner = () => {
                 style={{
                     insetBlockEnd: '-16px',
                 }}
-                formats={['avif', 'webp', 'auto']}
+                formats={['avif', 'webp']}
                 placeholder="none"
                 className={'public_signup_image'}
             />

--- a/src/features/pages/home/hero/index.tsx
+++ b/src/features/pages/home/hero/index.tsx
@@ -15,7 +15,7 @@ const HomeHeroSlider = loadable(() => pMinDelay(import('./slider'), 4000), {
                 objectFit="fill"
                 src="../../../../images/common/home/hero_1.png"
                 alt="person-hero-1"
-                formats={['avif', 'webp', 'auto']}
+                formats={['avif', 'webp']}
                 loading="eager"
                 quality={50}
                 placeholder="blurred"
@@ -31,7 +31,7 @@ const HomeHeroSliderEu = loadable(() => pMinDelay(import('./slider'), 4000), {
                 objectFit="fill"
                 src="../../../../images/common/home/eu_hero_person_5.png"
                 alt="person-hero-1"
-                formats={['avif', 'webp', 'auto']}
+                formats={['avif', 'webp']}
                 loading="eager"
                 quality={50}
                 placeholder="blurred"

--- a/src/features/pages/home/hero/slider/index.tsx
+++ b/src/features/pages/home/hero/slider/index.tsx
@@ -17,7 +17,7 @@ const HomeHeroSlider = () => {
                         objectFit="fill"
                         src="../../../../../images/common/home/hero_3.png"
                         alt="person-hero-3"
-                        formats={['avif', 'webp', 'auto']}
+                        formats={['avif', 'webp']}
                         placeholder="none"
                         quality={75}
                     />
@@ -30,7 +30,7 @@ const HomeHeroSlider = () => {
                         objectFit="fill"
                         src="../../../../../images/common/home/hero_4.png"
                         alt="person-hero-4"
-                        formats={['avif', 'webp', 'auto']}
+                        formats={['avif', 'webp']}
                         placeholder="none"
                     />
                 ),
@@ -45,7 +45,7 @@ const HomeHeroSlider = () => {
                             objectFit="fill"
                             src="../../../../../images/common/home/hero_2.png"
                             alt="person-hero-2"
-                            formats={['avif', 'webp', 'auto']}
+                            formats={['avif', 'webp']}
                             loading="eager"
                             placeholder="none"
                         />
@@ -58,7 +58,7 @@ const HomeHeroSlider = () => {
                             objectFit="fill"
                             src="../../../../../images/common/home/hero_1.png"
                             alt="person-hero-1"
-                            formats={['avif', 'webp', 'auto']}
+                            formats={['avif', 'webp']}
                             quality={50}
                             placeholder="none"
                         />
@@ -73,7 +73,7 @@ const HomeHeroSlider = () => {
                         objectFit="fill"
                         src="../../../../../images/common/home/eu_hero_person_5.png"
                         alt="person-hero-1"
-                        formats={['avif', 'webp', 'auto']}
+                        formats={['avif', 'webp']}
                         quality={50}
                         placeholder="none"
                     />

--- a/src/features/pages/home/markets/data.tsx
+++ b/src/features/pages/home/markets/data.tsx
@@ -17,7 +17,7 @@ export const market_items: SmartMarketItem[] = [
                 <StaticImage
                     src="../../../../images/common/home/market_forex.png"
                     alt="forex market"
-                    formats={['avif', 'webp', 'auto']}
+                    formats={['avif', 'webp']}
                     placeholder="none"
                 />
             ),
@@ -39,14 +39,14 @@ export const market_items: SmartMarketItem[] = [
                     <StaticImage
                         src="../../../../images/common/home/market_derived_eu.png"
                         alt="synthetic market"
-                        formats={['avif', 'webp', 'auto']}
+                        formats={['avif', 'webp']}
                         placeholder="none"
                     />
                 ) : (
                     <StaticImage
                         src="../../../../images/common/home/market_derived.png"
                         alt="synthetic market"
-                        formats={['avif', 'webp', 'auto']}
+                        formats={['avif', 'webp']}
                         placeholder="none"
                     />
                 ),
@@ -66,7 +66,7 @@ export const market_items: SmartMarketItem[] = [
                 <StaticImage
                     src="../../../../images/common/home/market_stocks_indices.png"
                     alt="stocks indices market"
-                    formats={['avif', 'webp', 'auto']}
+                    formats={['avif', 'webp']}
                     placeholder="none"
                 />
             ),
@@ -86,7 +86,7 @@ export const market_items: SmartMarketItem[] = [
                 <StaticImage
                     src="../../../../images/common/home/market_crypto.png"
                     alt="cryptocurrencies market"
-                    formats={['avif', 'webp', 'auto']}
+                    formats={['avif', 'webp']}
                     placeholder="none"
                 />
             ),
@@ -106,7 +106,7 @@ export const market_items: SmartMarketItem[] = [
                 <StaticImage
                     src="../../../../images/common/home/market_commodities.png"
                     alt="commodities market"
-                    formats={['avif', 'webp', 'auto']}
+                    formats={['avif', 'webp']}
                     placeholder="none"
                 />
             ),

--- a/src/features/pages/home/our-platforms/data.tsx
+++ b/src/features/pages/home/our-platforms/data.tsx
@@ -39,7 +39,7 @@ const platformSliderItems: SmartPlatformItem[] = [
                     objectFit="contain"
                     src="../../../../images/common/home/rebranding/platform_deriv_go.png"
                     alt="deriv go"
-                    formats={['avif', 'webp', 'auto']}
+                    formats={['avif', 'webp']}
                     placeholder="none"
                 />
             ),
@@ -122,7 +122,7 @@ const platformSliderItems: SmartPlatformItem[] = [
                         objectFit="contain"
                         src="../../../../images/common/home/rebranding/platform_mt5_eu.png"
                         alt="deriv mt5 eu"
-                        formats={['avif', 'webp', 'auto']}
+                        formats={['avif', 'webp']}
                         placeholder="none"
                     />
                 ) : (
@@ -130,7 +130,7 @@ const platformSliderItems: SmartPlatformItem[] = [
                         objectFit="contain"
                         src="../../../../images/common/home/rebranding/platform_mt5.png"
                         alt="deriv mt5"
-                        formats={['avif', 'webp', 'auto']}
+                        formats={['avif', 'webp']}
                         placeholder="none"
                     />
                 ),
@@ -162,7 +162,7 @@ const platformSliderItems: SmartPlatformItem[] = [
                     objectFit="contain"
                     src="../../../../images/common/home/rebranding/platform_deriv_trader.png"
                     alt="deriv trader"
-                    formats={['avif', 'webp', 'auto']}
+                    formats={['avif', 'webp']}
                     placeholder="none"
                 />
             ),
@@ -206,7 +206,7 @@ const platformSliderItems: SmartPlatformItem[] = [
                     objectFit="contain"
                     src="../../../../images/common/home/rebranding/platform_derivx.png"
                     alt="deriv x"
-                    formats={['avif', 'webp', 'auto']}
+                    formats={['avif', 'webp']}
                     placeholder="none"
                 />
             ),
@@ -247,7 +247,7 @@ const platformSliderItems: SmartPlatformItem[] = [
                     objectFit="contain"
                     src="../../../../images/common/home/rebranding/platform_deriv_ez.png"
                     alt="deriv ez"
-                    formats={['avif', 'webp', 'auto']}
+                    formats={['avif', 'webp']}
                     placeholder="none"
                 />
             ),
@@ -282,7 +282,7 @@ const platformSliderItems: SmartPlatformItem[] = [
                     objectFit="contain"
                     src="../../../../images/common/home/rebranding/platform_deriv_bot.png"
                     alt="deriv bot"
-                    formats={['avif', 'webp', 'auto']}
+                    formats={['avif', 'webp']}
                     placeholder="none"
                 />
             ),
@@ -317,7 +317,7 @@ const platformSliderItems: SmartPlatformItem[] = [
                     objectFit="contain"
                     src="../../../../images/common/home/rebranding/platform_smart_trader.png"
                     alt="deriv smart trader"
-                    formats={['avif', 'webp', 'auto']}
+                    formats={['avif', 'webp']}
                     placeholder="none"
                 />
             ),
@@ -352,7 +352,7 @@ const platformSliderItems: SmartPlatformItem[] = [
                     objectFit="contain"
                     src="../../../../images/common/home/rebranding/platform_binary_bot.png"
                     alt="binary bot"
-                    formats={['avif', 'webp', 'auto']}
+                    formats={['avif', 'webp']}
                     placeholder="none"
                 />
             ),
@@ -387,7 +387,7 @@ const platformSliderItems: SmartPlatformItem[] = [
                     objectFit="contain"
                     src="../../../../images/common/home/rebranding/platform_deriv_api.png"
                     alt="deriv api"
-                    formats={['avif', 'webp', 'auto']}
+                    formats={['avif', 'webp']}
                     placeholder="none"
                 />
             ),

--- a/src/features/pages/home/p2p-banner/index.tsx
+++ b/src/features/pages/home/p2p-banner/index.tsx
@@ -34,7 +34,7 @@ const P2PBanner = () => {
                     height={700}
                     objectFit="cover"
                     placeholder="none"
-                    formats={['avif', 'webp', 'auto']}
+                    formats={['avif', 'webp']}
                 />
             </Flex.Box>
         </Flex.Box>

--- a/src/features/pages/home/p2p-banner/p2p-image/index.tsx
+++ b/src/features/pages/home/p2p-banner/p2p-image/index.tsx
@@ -17,7 +17,7 @@ const P2PBannerImage = () => {
                         height={400}
                         objectFit="cover"
                         placeholder="none"
-                        formats={['avif', 'webp', 'auto']}
+                        formats={['avif', 'webp']}
                     />
                 ) : (
                     <StaticImage
@@ -26,7 +26,7 @@ const P2PBannerImage = () => {
                         height={400}
                         objectFit="cover"
                         placeholder="none"
-                        formats={['avif', 'webp', 'auto']}
+                        formats={['avif', 'webp']}
                     />
                 )}
             </Flex.Box>

--- a/src/pages/bug-bounty/_about-deriv.tsx
+++ b/src/pages/bug-bounty/_about-deriv.tsx
@@ -11,7 +11,6 @@ const query = graphql`
         deriv_platform: file(relativePath: { eq: "bug-bounty/devices.png" }) {
             childImageSharp {
                 gatsbyImageData(
-                    formats: [AUTO, WEBP]
                     layout: CONSTRAINED
                     quality: 70
                     breakpoints: [360, 992]

--- a/src/pages/careers/locations/minsk/index.tsx
+++ b/src/pages/careers/locations/minsk/index.tsx
@@ -16,42 +16,22 @@ const query = graphql`
         }
         minsk_grid_1: file(relativePath: { eq: "careers/minsk_grid_1.png" }) {
             childImageSharp {
-                gatsbyImageData(
-                    formats: [AUTO, WEBP]
-                    layout: CONSTRAINED
-                    quality: 70
-                    placeholder: NONE
-                )
+                gatsbyImageData(layout: CONSTRAINED, quality: 70, placeholder: NONE)
             }
         }
         minsk_grid_2: file(relativePath: { eq: "careers/minsk_grid_2.png" }) {
             childImageSharp {
-                gatsbyImageData(
-                    formats: [AUTO, WEBP]
-                    layout: CONSTRAINED
-                    quality: 70
-                    placeholder: NONE
-                )
+                gatsbyImageData(layout: CONSTRAINED, quality: 70, placeholder: NONE)
             }
         }
         minsk_grid_3: file(relativePath: { eq: "careers/minsk_grid_3.png" }) {
             childImageSharp {
-                gatsbyImageData(
-                    formats: [AUTO, WEBP]
-                    layout: CONSTRAINED
-                    quality: 70
-                    placeholder: NONE
-                )
+                gatsbyImageData(layout: CONSTRAINED, quality: 70, placeholder: NONE)
             }
         }
         minsk_grid_4: file(relativePath: { eq: "careers/minsk_grid_4.png" }) {
             childImageSharp {
-                gatsbyImageData(
-                    formats: [AUTO, WEBP]
-                    layout: CONSTRAINED
-                    quality: 70
-                    placeholder: NONE
-                )
+                gatsbyImageData(layout: CONSTRAINED, quality: 70, placeholder: NONE)
             }
         }
         minsk_map: file(relativePath: { eq: "maps/map-minsk-career.png" }) {

--- a/src/pages/home/_hero.tsx
+++ b/src/pages/home/_hero.tsx
@@ -83,7 +83,7 @@ const Hero = ({ is_ppc }: HeroProps) => {
                         src="../../images/common/home/hero_bg.png"
                         alt="world map"
                         loading="eager"
-                        formats={['avif', 'webp', 'auto']}
+                        formats={['avif', 'webp']}
                         quality={26}
                         objectFit="contain"
                         placeholder="none"

--- a/src/pages/home/_platform-slideshow.tsx
+++ b/src/pages/home/_platform-slideshow.tsx
@@ -47,7 +47,7 @@ const PlatformSlideshow = () => {
                         <StaticImage
                             src="../../images/common/home/hero_platform1.png"
                             alt="mobile app deriv go"
-                            formats={['avif', 'webp', 'auto']}
+                            formats={['avif', 'webp']}
                             quality={36}
                             loading="eager"
                             placeholder="none"
@@ -60,7 +60,7 @@ const PlatformSlideshow = () => {
                         <StaticImage
                             src="../../images/common/home/hero_platform2.png"
                             alt="laptop dtrader"
-                            formats={['avif', 'webp', 'auto']}
+                            formats={['avif', 'webp']}
                             quality={44}
                             placeholder="none"
                         />
@@ -72,7 +72,7 @@ const PlatformSlideshow = () => {
                         <StaticImage
                             src="../../images/common/home/hero_platform3.png"
                             alt="laptop mt5"
-                            formats={['avif', 'webp', 'auto']}
+                            formats={['avif', 'webp']}
                             quality={38}
                             placeholder="none"
                         />
@@ -84,7 +84,7 @@ const PlatformSlideshow = () => {
                         <StaticImage
                             src="../../images/common/home/hero_platform4.png"
                             alt="laptop deriv x"
-                            formats={['avif', 'webp', 'auto']}
+                            formats={['avif', 'webp']}
                             quality={44}
                             placeholder="none"
                         />
@@ -100,7 +100,7 @@ const PlatformSlideshow = () => {
                         <StaticImage
                             src="../../images/common/home/hero_platform1_eu.png"
                             alt="laptop dtrader eu"
-                            formats={['avif', 'webp', 'auto']}
+                            formats={['avif', 'webp']}
                             quality={44}
                             loading="eager"
                             placeholder="none"
@@ -113,7 +113,7 @@ const PlatformSlideshow = () => {
                         <StaticImage
                             src="../../images/common/home/hero_platform2_eu.png"
                             alt="laptop dmt5 eu"
-                            formats={['avif', 'webp', 'auto']}
+                            formats={['avif', 'webp']}
                             quality={38}
                             placeholder="none"
                         />


### PR DESCRIPTION
Co-authored with @yashim-deriv 

# Changes:
- Generate less formats. AVIF still requires a fallback (WEBP). WEBP no longer need a fallback to old generation web image format.
- Number of generated images is dropping from 1231 to 644 with this change.
- Build time (`npm run build`) is dropping from 12min30 to 8min45 on local computer with this change.


## Type of change
-   [ ] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [x] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
