### PR TITLE
Optimize build no dependency on lint for nothing

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -15,28 +15,7 @@ env:
     DATADOG_CLIENT_TOKEN: ${{ secrets.DATADOG_CLIENT_TOKEN }}
 
 jobs:
-    lint:
-        timeout-minutes: 10
-        runs-on: ubuntu-latest
-        environment: production
-
-        steps:
-            - name: Checkout 🛎️
-              uses: actions/checkout@v2.3.1
-
-            - name: Set up Node.js
-              uses: actions/setup-node@v3
-              with:
-                  node-version: 16
-                  cache: 'npm'
-
-            - name: Install Node.js dependencies
-              run: |
-                  npm ci
-                  npm test
-
     release-production:
-        needs: lint
         timeout-minutes: 40
         runs-on: ubuntu-latest
         environment: production

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -19,28 +19,7 @@ env:
   DATADOG_CLIENT_TOKEN: ${{ secrets.DATADOG_CLIENT_TOKEN }}
 
 jobs:
-  lint:
-    timeout-minutes: 10
-    runs-on: ubuntu-latest
-    environment: staging
-
-    steps:
-      - name: Checkout 🛎️
-        uses: actions/checkout@v2.3.1
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18
-          cache: "npm"
-
-      - name: Install Node.js dependencies
-        run: |
-          npm ci
-          npm test
-
   release-staging:
-    needs: lint
     timeout-minutes: 30
     runs-on: ubuntu-latest
     environment: staging


### PR DESCRIPTION
# Changes:
- Seems like we waste build time by doing `checkout`, `npm ci` then `npm test` one first time then in main job again. Removing the job dependency

## Type of change
-   [ ] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [x] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
