### PR TITLE
yashim/chore: disable portugese content

### DIFF
--- a/i18n-config.js
+++ b/i18n-config.js
@@ -31,12 +31,6 @@ module.exports = {
         short_name: 'PL',
         affiliate_lang: 5,
     },
-    pt: {
-        path: 'pt',
-        display_name: 'Português',
-        short_name: 'PT',
-        affiliate_lang: 9,
-    },
     ru: {
         path: 'ru',
         display_name: 'Русский',

--- a/i18n-config.js
+++ b/i18n-config.js
@@ -31,6 +31,12 @@ module.exports = {
         short_name: 'PL',
         affiliate_lang: 5,
     },
+    pt: {
+        path: 'pt',
+        display_name: 'Português',
+        short_name: 'PT',
+        affiliate_lang: 9,
+    },
     ru: {
         path: 'ru',
         display_name: 'Русский',

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -75,19 +75,8 @@ export const besquare_signup_url =
 export const binary_url = 'https://binary.com'
 export const brand_name = 'Deriv'
 export const client_token = 'pubc42fda54523c5fb23c564e3d8bceae88'
-export const deriv_app_languages = ['id', 'pt', 'es', 'ru', 'fr']
-export const smart_trader_languages = [
-    'es',
-    'fr',
-    'id',
-    'it',
-    'pl',
-    'pt',
-    'ru',
-    'vi',
-    'zh_cn',
-    'zh_tw',
-]
+export const deriv_app_languages = ['id', 'es', 'ru', 'fr']
+export const smart_trader_languages = ['es', 'fr', 'id', 'it', 'pl', 'ru', 'vi', 'zh_cn', 'zh_tw']
 export const deriv_status_page_url = 'https://deriv.statuspage.io'
 export const derivx_ios_url = 'https://apps.apple.com/us/app/deriv-x/id1563337503'
 export const derivx_android_url = 'https://play.google.com/store/apps/details?id=com.deriv.dx'

--- a/src/features/components/molecules/language-switcher/useLangSwitcher.tsx
+++ b/src/features/components/molecules/language-switcher/useLangSwitcher.tsx
@@ -23,22 +23,24 @@ type i18nLangConfigObject = {
 }
 
 const supported_languages = Object.keys(language_config)
-const disabled_lang = ['ach', 'pt']
+const disabled_lang = ['ach']
 
-const languages: TLanguageObject[] = supported_languages.map((langItem) => {
-    if (disabled_lang.includes(langItem) && isProduction()) return
+const languages: TLanguageObject[] = supported_languages
+    .filter((lang) => ['pt'].includes(lang))
+    .map((langItem) => {
+        if (disabled_lang.includes(langItem) && isProduction()) return
 
-    const { display_name, path } = language_config[langItem]
-    const to = `/${path}/`
-    const text = display_name
+        const { display_name, path } = language_config[langItem]
+        const to = `/${path}/`
+        const text = display_name
 
-    return {
-        key: langItem,
-        url: to,
-        display_name: text,
-        path,
-    }
-})
+        return {
+            key: langItem,
+            url: to,
+            display_name: text,
+            path,
+        }
+    })
 
 const useLangSwitcher = () => {
     const { i18n } = useTranslation()

--- a/src/features/components/molecules/language-switcher/useLangSwitcher.tsx
+++ b/src/features/components/molecules/language-switcher/useLangSwitcher.tsx
@@ -23,10 +23,10 @@ type i18nLangConfigObject = {
 }
 
 const supported_languages = Object.keys(language_config)
-const disabled_lang = ['ach']
+const disabled_lang = ['ach', 'pt']
 
 const languages: TLanguageObject[] = supported_languages.map((langItem) => {
-    if (disabled_lang.includes(langItem) && isProduction()) return undefined
+    if (disabled_lang.includes(langItem) && isProduction()) return
 
     const { display_name, path } = language_config[langItem]
     const to = `/${path}/`

--- a/src/features/components/molecules/language-switcher/useLangSwitcher.tsx
+++ b/src/features/components/molecules/language-switcher/useLangSwitcher.tsx
@@ -23,24 +23,22 @@ type i18nLangConfigObject = {
 }
 
 const supported_languages = Object.keys(language_config)
-const disabled_lang = ['ach']
+const disabled_lang = ['ach', 'pt']
 
-const languages: TLanguageObject[] = supported_languages
-    .filter((lang) => ['pt'].includes(lang))
-    .map((langItem) => {
-        if (disabled_lang.includes(langItem) && isProduction()) return
+const languages: TLanguageObject[] = supported_languages.map((langItem) => {
+    if (disabled_lang.includes(langItem) && isProduction()) return
 
-        const { display_name, path } = language_config[langItem]
-        const to = `/${path}/`
-        const text = display_name
+    const { display_name, path } = language_config[langItem]
+    const to = `/${path}/`
+    const text = display_name
 
-        return {
-            key: langItem,
-            url: to,
-            display_name: text,
-            path,
-        }
-    })
+    return {
+        key: langItem,
+        url: to,
+        display_name: text,
+        path,
+    }
+})
 
 const useLangSwitcher = () => {
     const { i18n } = useTranslation()

--- a/src/features/components/molecules/language-switcher/useLangSwitcher.tsx
+++ b/src/features/components/molecules/language-switcher/useLangSwitcher.tsx
@@ -26,7 +26,7 @@ const supported_languages = Object.keys(language_config)
 const disabled_lang = ['ach']
 
 const languages: TLanguageObject[] = supported_languages.map((langItem) => {
-    if (disabled_lang.includes(langItem) && isProduction()) return
+    if (disabled_lang.includes(langItem) && isProduction()) return undefined
 
     const { display_name, path } = language_config[langItem]
     const to = `/${path}/`

--- a/src/pages/landing/ebooks/crypto.tsx
+++ b/src/pages/landing/ebooks/crypto.tsx
@@ -50,7 +50,7 @@ const query = graphql`
 `
 
 const StocksEbook = ({ language }: StocksEbookProps) => {
-    const ebook_languages = ['es', 'pt', 'fr']
+    const ebook_languages = ['es', 'fr']
     const ebook_image = ebook_languages.includes(language) ? `_${language}` : ''
 
     const data = useStaticQuery(query)

--- a/src/pages/regulatory/_document_accordion.tsx
+++ b/src/pages/regulatory/_document_accordion.tsx
@@ -117,7 +117,7 @@ const DocumentAccordion = (locale: DocumentAccordionProps) => {
     }
 
     const selected_language = locale.locale.language || 'en'
-    const supported_languages = ['es', 'it', 'pl', 'pt']
+    const supported_languages = ['es', 'it', 'pl']
 
     const is_supported_language = (language: string) => supported_languages.includes(language)
 

--- a/src/pages/terms-and-conditions/_business-grid.tsx
+++ b/src/pages/terms-and-conditions/_business-grid.tsx
@@ -43,7 +43,7 @@ const Col = ({ Icon, content, link_title, title, url }: ColProps) => (
 
 const PartnersGuidePdf = () => {
     const language = getLanguage()
-    const supported_languages = ['fr', 'id', 'pt', 'ru', 'es', 'vi']
+    const supported_languages = ['fr', 'id', 'ru', 'es', 'vi']
     const pdf_lang = supported_languages.includes(language) ? language : 'english'
     const url = `/tnc/business-partners-guide-${pdf_lang}.pdf`
     return (


### PR DESCRIPTION
Changes:

-   Disable all `portuguse` related contents: language-switcher, pdfs, marketing materials

## Type of change

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
