### PR TITLE
Adrienne & Jim /  Fixed an issue where stage option is not passed to the gatsby babel preset

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,11 @@
 {
-    "presets": ["babel-preset-gatsby"],
+    "presets": [
+        [
+            "babel-preset-gatsby",
+            {
+                "stage": "build-javascript" // This fixes the code splitting issue, refer https://github.com/gatsbyjs/gatsby/issues/35731
+            }
+        ]
+    ],
     "plugins": ["@loadable/babel-plugin"]
 }


### PR DESCRIPTION
Changes:
-  The Babel preset for Gatsby `babel-preset-gatsby` was not used since the `stage` option for `build-javascript` stage was not passed in, thus resulting in the chunks being bundled into a big, single chunk.
<img width="1840" alt="Screenshot 2023-08-25 at 2 53 10 PM" src="https://github.com/binary-com/deriv-com/assets/103016120/43edca2f-4dbc-4079-a292-36cc379ddf64">

Once the preset argument has been passed, the chunks are splitted accordingly:
<img width="1796" alt="Screenshot 2023-08-25 at 2 44 18 PM" src="https://github.com/binary-com/deriv-com/assets/103016120/0c339f1a-5425-44e6-8eca-e5ef6d585358">


Refer to issue https://github.com/gatsbyjs/gatsby/issues/35731 for more information.
## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
