### PR TITLE
Hasan/fix: side navigation adjustment

### DIFF
--- a/src/features/components/templates/navigation/template/mobile-menu/mobile-menu.module.scss
+++ b/src/features/components/templates/navigation/template/mobile-menu/mobile-menu.module.scss
@@ -7,7 +7,7 @@
     block-size: calc(100vh - 7rem);
     background-color: $color-white;
     opacity: 1;
-    inset-inline-start: -100vh;
+    inset-inline-start: -100%;
     overflow: scroll;
     transition:  0.5s ease 0ms;
     box-shadow: 0 16px 20px 0 rgba(0, 0, 0, 0.1);


### PR DESCRIPTION
Changes:
![image (21)](https://github.com/binary-com/deriv-com/assets/126637868/140338d3-b90d-40c2-845b-76149bdec42f)

Updated  `inset-inline-start` css value from `-100vh` to `-100%` fix the side navigation adjustment.

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [x] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
