### PR TITLE
Hasan/fix: timeline dot line issue

### DIFF
--- a/src/features/components/molecules/timeline-item/style.module.scss
+++ b/src/features/components/molecules/timeline-item/style.module.scss
@@ -3,6 +3,7 @@
 .timeline_item {
     max-inline-size: 74.4rem;
     position: relative;
+    isolation: isolate;
     &:before {
         position: absolute;
         content: '';


### PR DESCRIPTION
Changes:

-  Fixing Trade > Options page :: "Start trading options on Deriv" section doesn’t show the dotted lines to show the flow

<img width="1508" alt="Screenshot 2023-09-06 at 4 28 56 PM" src="https://github.com/binary-com/deriv-com/assets/126637868/c8f0d2cf-0e6a-4273-a70c-5280f6ed16d9">

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [x] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
