### PR TITLE
fix: :bug: having two label for symbol field

### DIFF
--- a/src/components/elements/dropdown-search.tsx
+++ b/src/components/elements/dropdown-search.tsx
@@ -58,7 +58,6 @@ const DropdownSearch = ({
     label,
     onChange,
     selected_item,
-    value,
     ...props
 }: DropdownProps) => {
     const [input_value, setInputValue] = useState('')
@@ -110,11 +109,7 @@ const DropdownSearch = ({
                 {...props}
             >
                 <Flex ai="center">
-                    <StyledLabel
-                        active={
-                            is_open || (!is_open && selected_item) || (!is_open && value !== '')
-                        }
-                    >
+                    <StyledLabel active={is_open || (!is_open && selected_item)}>
                         {label}
                     </StyledLabel>
                     <DropdownInput


### PR DESCRIPTION
Changes:

- Fixing the issue where we have two labels for the symbol field in the margin calculator

![image](https://github.com/binary-com/deriv-com/assets/64970259/1936f8bc-0bdd-41e0-a1c8-92071674661d)


## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
