### PR TITLE
Modified e2e smoke test section

### DIFF
--- a/.github/workflows/generate-preview-link.yml
+++ b/.github/workflows/generate-preview-link.yml
@@ -207,6 +207,6 @@ jobs:
                 # in GitHub repo → Settings → Secrets → Actions
                 CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
                 # Creating a token https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token
-                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
                 # Set Base Url from client_payload.
                 CYPRESS_BASE_URL: ${{ github.event.client_payload.baseurl }}

--- a/.github/workflows/generate-preview-link.yml
+++ b/.github/workflows/generate-preview-link.yml
@@ -182,15 +182,31 @@ jobs:
                   message: ${{steps.generate_preview_url.outputs.comment || steps.generate_failure_comment.outputs.comment }}
                   recreate: true
 
-            - name: E2E Smoke Test
-              run: |
-                  curl -X POST \
-                  -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-                  -H "Accept: application/vnd.github.everest-preview+json" \
-                  "https://api.github.com/repos/deriv-com/e2e-deriv-com/dispatches" \
-                  -d '{
-                    "event_type": "run-e2e-tests",
-                    "client_payload": {
-                      "baseurl": "${{steps.publish-to-pages.outputs.preview_url}}"
-                    }
-                  }'
+            - name: e2e Smoke Tests
+              uses: actions/checkout@v4
+              with:
+                repository: deriv-com/e2e-deriv-com # Replace with your repository name
+
+            - name: Cypress run
+              # Uses the official Cypress GitHub action https://github.com/cypress-io/github-action
+              uses: cypress-io/github-action@v6
+              with:
+                # Starts web server for E2E tests - replace with your own server invocation
+                # https://docs.cypress.io/guides/continuous-integration/introduction#Boot-your-server
+                # start: npm start
+                # wait-on: 'http://localhost:3000' # Waits for above
+                # Records to Cypress Cloud 
+                # https://docs.cypress.io/guides/cloud/projects#Set-up-a-project-to-record
+                record: true
+                parallel: true # Runs test in parallel using settings above
+                spec: cypress/e2e/smoke/*.js
+                group: 'Smoke Tests'
+        
+              env:
+                # For recording and parallelization to work you must set your CYPRESS_RECORD_KEY
+                # in GitHub repo → Settings → Secrets → Actions
+                CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+                # Creating a token https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token
+                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                # Set Base Url from client_payload.
+                CYPRESS_BASE_URL: ${{ github.event.client_payload.baseurl }}


### PR DESCRIPTION
No longer call the tests via API. 
Now we're pulling the test code and running via Cypress Cloud.

Changes:

-   ...

## Type of change

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [x ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
