### PR TITLE
Konstantinos / Remove 'Demo' tag on DSI page

### DIFF
--- a/src/pages/markets/instruments/_drift_switch_indices.tsx
+++ b/src/pages/markets/instruments/_drift_switch_indices.tsx
@@ -6,7 +6,12 @@ const DriftSwitchIndices = () => {
     return (
         <>
             {drift_switch_indices.map((symbol) => (
-                <Symbol key={symbol.text} src={symbol.src} text={symbol.text} has_demo_tag={true} />
+                <Symbol
+                    key={symbol.text}
+                    src={symbol.src}
+                    text={symbol.text}
+                    has_demo_tag={false}
+                />
             ))}
         </>
     )


### PR DESCRIPTION
Changes:
Remove Demo tag:
![image](https://github.com/binary-com/deriv-com/assets/104083272/441d2bef-7034-45e6-96ad-ece6e085d426)

## Type of change

-   [ ] Bug fix
-   [ ] New feature
-   [x] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
