### PR TITLE
Fix etf kid for non eng language

### DIFF
--- a/src/pages/regulatory/_document_accordion.tsx
+++ b/src/pages/regulatory/_document_accordion.tsx
@@ -149,7 +149,7 @@ const DocumentAccordion = (locale: DocumentAccordionProps) => {
                                 color="red"
                                 target="_blank"
                                 rel="noopener noreferrer"
-                                href={`/regulatory/kis_cr/${
+                                href={`/regulatory/kid/${
                                     is_supported_language(selected_language) && !data.is_only_en
                                         ? selected_language + '/'
                                         : ''

--- a/src/pages/regulatory/_document_accordion.tsx
+++ b/src/pages/regulatory/_document_accordion.tsx
@@ -174,7 +174,7 @@ const DocumentAccordion = (locale: DocumentAccordionProps) => {
                                 target="_blank"
                                 rel="noopener noreferrer"
                                 href={`/regulatory/kid/${
-                                    is_supported_language(selected_language)
+                                    is_supported_language(selected_language) && !data.is_only_en
                                         ? selected_language + '/'
                                         : ''
                                 }${data.ref}`}

--- a/src/pages/regulatory/_document_accordion.tsx
+++ b/src/pages/regulatory/_document_accordion.tsx
@@ -149,8 +149,8 @@ const DocumentAccordion = (locale: DocumentAccordionProps) => {
                                 color="red"
                                 target="_blank"
                                 rel="noopener noreferrer"
-                                href={`/regulatory/kid/${
-                                    is_supported_language(selected_language)
+                                href={`/regulatory/kis_cr/${
+                                    is_supported_language(selected_language) && !data.is_only_en
                                         ? selected_language + '/'
                                         : ''
                                 }${data.ref}`}

--- a/src/pages/regulatory/data/_kid_data.tsx
+++ b/src/pages/regulatory/data/_kid_data.tsx
@@ -31,11 +31,13 @@ const kid_data: kidType[] = [
     {
         title: '_t_CFDs - Synthetics: Volatility 250 (1s) Index_t_',
         ref: 'kid_deriv_CFD_synthetic_vol_250.pdf',
+        is_only_en: true,
     },
 
     {
         title: '_t_CFDs - Synthetics: Crash 300 Index_t_',
         ref: 'kid_deriv_CFD_synthetic_crash_300.pdf',
+        is_only_en: true,
     },
     {
         title: '_t_CFDs - ETFs_t_',
@@ -55,10 +57,12 @@ const kid_data_multiplier = [
     {
         title: '_t_Multipliers - Synthetics: Volatility 250 (1s) Index_t_',
         ref: 'kid_deriv_multipliers_synthetics_vol_250.pdf',
+        is_only_en: true,
     },
     {
         title: '_t_Multipliers - Synthetics: Crash 300 Index_t_',
         ref: 'kid_deriv_multipliers_synthetics_crash_300.pdf',
+        is_only_en: true,
     },
 ]
 

--- a/src/pages/regulatory/data/_kid_data.tsx
+++ b/src/pages/regulatory/data/_kid_data.tsx
@@ -3,6 +3,7 @@ import { TString } from 'types/generics'
 type kidType = {
     title: TString
     ref: string
+    is_only_en?: boolean
 }
 
 const kid_data: kidType[] = [
@@ -39,6 +40,7 @@ const kid_data: kidType[] = [
     {
         title: '_t_CFDs - ETFs_t_',
         ref: 'kid_deriv_cfds_etfs.pdf',
+        is_only_en: true,
     },
 ]
 const kid_data_multiplier = [


### PR DESCRIPTION
Changes:

-  ETF key information document shows 404 for few languages, fixing as it only has eng version ( for all other PDFs the 4 languages is supported) 

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
