### PR TITLE
mitra/ hide cTrader for eu

### DIFF
--- a/src/features/pages/markets/etf/trades-available/data.tsx
+++ b/src/features/pages/markets/etf/trades-available/data.tsx
@@ -46,6 +46,9 @@ export const trade_types: TradeType[] = [
                         to: '/deriv-ctrader',
                     },
                 },
+                visibility: {
+                    is_eu: false,
+                },
             },
         ],
     },


### PR DESCRIPTION
Changes:

-  hiding mention of Ctrader for eu in etf page

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
