### PR TITLE
Add env variables in build step

### DIFF
--- a/.github/workflows/generate-preview-link.yml
+++ b/.github/workflows/generate-preview-link.yml
@@ -113,6 +113,13 @@ jobs:
 
             - name: Build project
               id: build-project
+              env:
+                  GATSBY_ENV: staging
+                  GATSBY_GROWTHBOOK_CLIENT_KEY: ${{ secrets.GATSBY_GROWTHBOOK_CLIENT_KEY }}
+                  GATSBY_GROWTHBOOK_DECRYPTION_KEY: ${{ secrets.GATSBY_GROWTHBOOK_DECRYPTION_KEY }}
+                  GATSBY_RUDDERSTACK_STAGING_KEY: ${{ secrets.GATSBY_RUDDERSTACK_STAGING_KEY }}
+                  GATSBY_RUDDERSTACK_PRODUCTION_KEY: ${{ secrets.GATSBY_RUDDERSTACK_PRODUCTION_KEY }}
+                  GATSBY_STRAPI_TOKEN: ${{ secrets.GATSBY_STRAPI_TOKEN }}
               run: npm run build
 
             - name: Publish to Cloudflare Pages


### PR DESCRIPTION
Changes:

Add env variables in the build step to fix growth book issue in test links.
