### PR TITLE
feat: remove demo and add real button back

### DIFF
--- a/src/features/components/atoms/tab/tab-switcher/index.tsx
+++ b/src/features/components/atoms/tab/tab-switcher/index.tsx
@@ -8,7 +8,7 @@ import * as styles from './tab-switcher.module.scss'
 import { Localize } from 'components/localization'
 import dclsx from 'features/utils/dclsx'
 
-const TabSwitcher = ({ tab, onTabClick, is_ctrader = false }: Omit<StepperTabTypes, 'items'>) => {
+const TabSwitcher = ({ tab, onTabClick }: Omit<StepperTabTypes, 'items'>) => {
     return (
         <FlexBoxContainer
             direction={'col'}
@@ -29,22 +29,18 @@ const TabSwitcher = ({ tab, onTabClick, is_ctrader = false }: Omit<StepperTabTyp
                         <Localize translate_text={'_t_Demo account _t_'} />
                     </Typography.Paragraph>
                 </TabButton>
-                {!is_ctrader && (
-                    <TabButton
-                        className={dclsx(
-                            tab === 'real'
-                                ? styles.tab_switcher_active
-                                : styles.tab_switcher_unactive,
-                            styles.real_tab_button,
-                        )}
-                        style={{ background: 'transparent' }}
-                        onClick={() => onTabClick('real')}
-                    >
-                        <Typography.Paragraph size={'xlarge'} align={'center'}>
-                            <Localize translate_text={'_t_Real account _t_'} />
-                        </Typography.Paragraph>
-                    </TabButton>
-                )}
+                <TabButton
+                    className={dclsx(
+                        tab === 'real' ? styles.tab_switcher_active : styles.tab_switcher_unactive,
+                        styles.real_tab_button,
+                    )}
+                    style={{ background: 'transparent' }}
+                    onClick={() => onTabClick('real')}
+                >
+                    <Typography.Paragraph size={'xlarge'} align={'center'}>
+                        <Localize translate_text={'_t_Real account _t_'} />
+                    </Typography.Paragraph>
+                </TabButton>
             </FlexBox.Box>
         </FlexBoxContainer>
     )

--- a/src/features/components/templates/banners/deriv-products-hero/products-logo-and-text.tsx
+++ b/src/features/components/templates/banners/deriv-products-hero/products-logo-and-text.tsx
@@ -8,17 +8,15 @@ interface ProductsLogoTextProps {
 }
 
 const ProductsLogoAndText = ({ contentData }: ProductsLogoTextProps) => {
-    const { mobile_logo, logo, demo_icon, mobile_demo_icon } = contentData
+    const { mobile_logo, logo } = contentData
 
     return (
         <FlexBox.Box className={hero_image} justify="start">
             <FlexBox.Box visible="phone-and-tablet" align="center" gap="4x">
                 {mobile_logo}
-                {mobile_demo_icon}
             </FlexBox.Box>
             <FlexBox.Box visible="larger-than-tablet" align="center" gap="4x">
                 {logo}
-                {demo_icon}
             </FlexBox.Box>
         </FlexBox.Box>
     )

--- a/src/features/components/templates/banners/deriv-products-hero/types.ts
+++ b/src/features/components/templates/banners/deriv-products-hero/types.ts
@@ -6,8 +6,6 @@ export type DerivProductContentType = {
     hero: ReactElement
     hero_mobile: ReactElement
     logo: ReactElement
-    demo_icon: ReactElement
-    mobile_demo_icon: ReactElement
     mobile_logo: ReactElement
     product_water_mark_logo?: ReactElement
     product_water_mark_logo_mobile?: ReactElement

--- a/src/features/pages/deriv-ctrader/hero-banner/data.tsx
+++ b/src/features/pages/deriv-ctrader/hero-banner/data.tsx
@@ -31,6 +31,4 @@ export const hero_content_data: DerivProductContentType = {
     ),
     logo: <Image src={CTraderLogo} height={64} alt={'_t_Deriv ctrader logo_t_'} />,
     mobile_logo: <Image src={CTraderLogo} height={32} alt={'_t_Deriv ctrader logo_t_'} />,
-    demo_icon: <Image src={DemoLogo} height={28} width={55} alt={'_t_demo_t_'} />,
-    mobile_demo_icon: <Image src={DemoLogo} height={24} width={49} alt={'_t_demo_t_'} />,
 }


### PR DESCRIPTION
Changes:

Add real account button back in cTrader and remove the Demo icon

![image](https://github.com/binary-com/deriv-com/assets/104083272/1793690a-abc6-4809-aed6-3ed99b3b73ad)
![image](https://github.com/binary-com/deriv-com/assets/104083272/4f2e0777-8afb-4fa3-88cf-0a73c63c1d81)

## Type of change

-   [ ] Bug fix
-   [ ] New feature
-   [x] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
