### PR TITLE
Konstantinos / Update the name of Drift switch indices in Deriv website. 

### DIFF
--- a/src/pages/markets/static/content/_cfds.tsx
+++ b/src/pages/markets/static/content/_cfds.tsx
@@ -123,7 +123,7 @@ export const synthetic_cfds: TMarketContent = {
     content: [
         {
             id: 'drift-switch-indices',
-            title: '_t_Drift switch indices_t_',
+            title: '_t_Drift switching indices_t_',
             component: <DriftSwitchIndices />,
             details: <DriftSwitchDetails />,
         },


### PR DESCRIPTION
Changes:

Change the name of the Drift switch indices to Drift switching indices. 

## Type of change

-   [ ] Bug fix
-   [ ] New feature
-   [x] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
