### PR TITLE
Bala/capture cf pages preview URL to run lighthouse and smoke test

### DIFF
--- a/.github/workflows/generate-preview-link.yml
+++ b/.github/workflows/generate-preview-link.yml
@@ -59,6 +59,7 @@ jobs:
             - name: Post Cloudflare Pages Preview comment
               uses: marocchino/sticky-pull-request-comment@v2
               with:
+                  GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
                   header: Cloudflare Pages Preview Comment
                   number: ${{steps.pr_information.outputs.issue_number}}
                   message: ${{steps.generate_action_url.outputs.comment}}
@@ -183,6 +184,7 @@ jobs:
               if: success() || failure()
               uses: marocchino/sticky-pull-request-comment@v2
               with:
+                  GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
                   header: Cloudflare Pages Preview Comment
                   number: ${{steps.pr_information.outputs.issue_number}}
                   message: ${{steps.generate_preview_url.outputs.comment || steps.generate_failure_comment.outputs.comment }}

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,16 +1,16 @@
 name: Deriv Lighthouse Audit
 
 permissions:
-  actions: write
-  checks: write
-  contents: write
-  deployments: write
-  pull-requests: write
-  statuses: write
+    actions: write
+    checks: write
+    contents: write
+    deployments: write
+    pull-requests: write
+    statuses: write
 
 on:
     issue_comment:
-        types: [edited]
+        types: [created]
 
 jobs:
     generate_lighthouse_audit:
@@ -26,9 +26,9 @@ jobs:
                   header: lighthouse
                   message: |
                       Running Lighthouse audit...
-            - name: Capture Vercel preview URL
-              id: vercel_preview_url
-              uses: binary-com/vercel-preview-url-action@v1.0.5
+            - name: Capture preview URL
+              id: capture_preview_url
+              uses: deriv-com/capture-url-from-issue-comment@v1.0.4
               with:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             - uses: actions/checkout@v3
@@ -37,7 +37,7 @@ jobs:
               uses: treosh/lighthouse-ci-action@v9
               with:
                   urls: |
-                      ${{ steps.vercel_preview_url.outputs.vercel_preview_url }}
+                      ${{ steps.capture_preview_url.outputs.url }}
                   uploadArtifacts: true
                   temporaryPublicStorage: true
                   runs: 5
@@ -83,7 +83,6 @@ jobs:
                        core.setOutput("best_practices_color", score(result['best-practices']));
                        core.setOutput("full_report", full_report);
 
-
             - name: Add comment to PR
               id: comment_to_pr
               uses: marocchino/sticky-pull-request-comment@v2
@@ -100,83 +99,83 @@ jobs:
                   status: custom
                   fields: workflow,job,commit,repo
                   custom_payload: |
-                    {
-                        "blocks": [
-                          {
-                            "type": "section",
-                            "text": {
-                              "type": "plain_text",
-                              "emoji": true,
-                              "text": "It appears that this pull request has not met the required performance score."
-                            }
-                          },
-                          {
-                            "type": "divider"
-                          },
-                          {
-                            "type": "section",
-                            "text": {
-                              "type": "mrkdwn",
-                              "text": "*${{ steps.format_lighthouse_score.outputs.performance_color }} PERFORMANCE:* ${{ steps.format_lighthouse_score.outputs.performance }}\n\n*${{ steps.format_lighthouse_score.outputs.accessibility_color }} ACCESSIBILITY:* ${{ steps.format_lighthouse_score.outputs.accessibility }}\n\n*${{ steps.format_lighthouse_score.outputs.best_practices_color }} BEST PRACTICES:* ${{ steps.format_lighthouse_score.outputs.best_practices }}\n\n*${{ steps.format_lighthouse_score.outputs.seo_color }} SEO:* ${{ steps.format_lighthouse_score.outputs.seo }} \n\n*${{ steps.format_lighthouse_score.outputs.pwa_color }} PWA:* ${{ steps.format_lighthouse_score.outputs.pwa }}"
-                            }
-                          },
-                          {
-                            "type": "divider"
-                          },
-                          {
-                            "type": "section",
-                            "text": {
-                              "type": "mrkdwn",
-                              "text": "*User: <${{ github.event.issue.user.url }}|${{ github.event.issue.user.login }}>*\n*Link:* ${{ github.event.issue.pull_request.html_url }}\n*Title:* ${{ github.event.issue.title }}\n*Status:* ${{ github.event.issue.state }}"
-                            },
-                            "accessory": {
-                              "type": "image",
-                              "image_url": "${{ github.event.issue.user.avatar_url }}",
-                              "alt_text": "${{ github.event.issue.user.login }}"
-                            }
-                          },
-                          {
-                            "type": "divider"
-                          },
-                          {
-                            "type": "context",
-                            "elements": [
-                              {
-                                "type": "image",
-                                "image_url": "https://api.slack.com/img/blocks/bkb_template_images/notificationsWarningIcon.png",
-                                "alt_text": "notifications warning icon"
-                              },
-                              {
-                                "type": "mrkdwn",
-                                "text": "*<!subteam^S04RV6RFCTW> please check the PR*"
-                              }
-                            ]
-                          },
-                          {
-                            "type": "divider"
-                          },
-                          {
-                            "type": "section",
-                            "text": {
-                              "type": "mrkdwn",
-                              "text": "Want the full lighthouse report?"
-                            },
-                            "accessory": {
-                              "type": "button",
+                      {
+                          "blocks": [
+                            {
+                              "type": "section",
                               "text": {
                                 "type": "plain_text",
-                                "text": "View",
-                                "emoji": true
+                                "emoji": true,
+                                "text": "It appears that this pull request has not met the required performance score."
+                              }
+                            },
+                            {
+                              "type": "divider"
+                            },
+                            {
+                              "type": "section",
+                              "text": {
+                                "type": "mrkdwn",
+                                "text": "*${{ steps.format_lighthouse_score.outputs.performance_color }} PERFORMANCE:* ${{ steps.format_lighthouse_score.outputs.performance }}\n\n*${{ steps.format_lighthouse_score.outputs.accessibility_color }} ACCESSIBILITY:* ${{ steps.format_lighthouse_score.outputs.accessibility }}\n\n*${{ steps.format_lighthouse_score.outputs.best_practices_color }} BEST PRACTICES:* ${{ steps.format_lighthouse_score.outputs.best_practices }}\n\n*${{ steps.format_lighthouse_score.outputs.seo_color }} SEO:* ${{ steps.format_lighthouse_score.outputs.seo }} \n\n*${{ steps.format_lighthouse_score.outputs.pwa_color }} PWA:* ${{ steps.format_lighthouse_score.outputs.pwa }}"
+                              }
+                            },
+                            {
+                              "type": "divider"
+                            },
+                            {
+                              "type": "section",
+                              "text": {
+                                "type": "mrkdwn",
+                                "text": "*User: <${{ github.event.issue.user.url }}|${{ github.event.issue.user.login }}>*\n*Link:* ${{ github.event.issue.pull_request.html_url }}\n*Title:* ${{ github.event.issue.title }}\n*Status:* ${{ github.event.issue.state }}"
                               },
-                              "value": "click_me_123",
-                              "url": "${{ steps.format_lighthouse_score.outputs.full_report }}",
-                              "action_id": "button-action"
+                              "accessory": {
+                                "type": "image",
+                                "image_url": "${{ github.event.issue.user.avatar_url }}",
+                                "alt_text": "${{ github.event.issue.user.login }}"
+                              }
+                            },
+                            {
+                              "type": "divider"
+                            },
+                            {
+                              "type": "context",
+                              "elements": [
+                                {
+                                  "type": "image",
+                                  "image_url": "https://api.slack.com/img/blocks/bkb_template_images/notificationsWarningIcon.png",
+                                  "alt_text": "notifications warning icon"
+                                },
+                                {
+                                  "type": "mrkdwn",
+                                  "text": "*<!subteam^S04RV6RFCTW> please check the PR*"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "divider"
+                            },
+                            {
+                              "type": "section",
+                              "text": {
+                                "type": "mrkdwn",
+                                "text": "Want the full lighthouse report?"
+                              },
+                              "accessory": {
+                                "type": "button",
+                                "text": {
+                                  "type": "plain_text",
+                                  "text": "View",
+                                  "emoji": true
+                                },
+                                "value": "click_me_123",
+                                "url": "${{ steps.format_lighthouse_score.outputs.full_report }}",
+                                "action_id": "button-action"
+                              }
+                            },
+                            {
+                              "type": "divider"
                             }
-                          },
-                          {
-                            "type": "divider"
-                          }
-                        ]
-                      }
+                          ]
+                        }
               env:
                   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_LIGHTHOUSE }}

--- a/.github/workflows/smoketests.yml
+++ b/.github/workflows/smoketests.yml
@@ -8,68 +8,68 @@ permissions:
     pull-requests: write
     statuses: write
 
-on: 
+on:
     issue_comment:
-        types: [edited]
-        
+        types: [created]
+
 jobs:
-  cypress-run:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false 
-      matrix:
-        containers: [1,2,3,4,5]
+    cypress-run:
+        runs-on: ubuntu-latest
+        strategy:
+            fail-fast: false
+            matrix:
+                containers: [1, 2, 3, 4, 5]
 
-    steps:
-    - name: Capture Vercel preview URL
-      id: vercel_preview_url
-      uses: binary-com/vercel-preview-url-action@v1.0.5
-      with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          
-    - name: Checkout external repository with Cypress tests
-      uses: actions/checkout@v4
-      with:
-        repository: deriv-com/e2e-deriv-com
+        steps:
+            - name: Capture preview URL
+              id: capture_preview_url
+              uses: deriv-com/capture-url-from-issue-comment@v1.0.4
+              with:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Cypress run
-      # Uses the official Cypress GitHub action https://github.com/cypress-io/github-action
-      uses: cypress-io/github-action@v6
-      with:
-        # Records to Cypress Cloud 
-        # https://docs.cypress.io/guides/cloud/projects#Set-up-a-project-to-record
-        record: true
-        parallel: true # Runs test in parallel using settings above
-        spec: cypress/e2e/smoke/*.js
-        group: 'Smoke Tests'
-        
-      env:
-        # For recording and parallelization to work you must set your CYPRESS_RECORD_KEY
-        # in GitHub repo → Settings → Secrets → Actions
-        CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
-        # Creating a token https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token
-        GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-        # Set Base Url from client_payload.
-        CYPRESS_BASE_URL: ${{ steps.vercel_preview_url.outputs.vercel_preview_url }}
-        # Send PR details to Cypress test run
-        COMMIT_INFO_MESSAGE: PR "${{ github.event.issue.number }}" in Repo "${{ github.repository }}" (v2)
+            - name: Checkout external repository with Cypress tests
+              uses: actions/checkout@v4
+              with:
+                  repository: deriv-com/e2e-deriv-com
 
-    - name: Set comments message
-      id: set_msg 
-      if: always()
-      run: |
-        # Using shell script to conditionally set the message
-        if [[ "${{ job.status }}" == "success" ]]; then
-          echo "msg=:rocket: Smoke test run (${{ matrix.containers }}) passed successfully!" >> $GITHUB_OUTPUT
-        else
-          echo "msg=:x: Smoke test run (${{ matrix.containers }}) failed. See logs for details: [Visit Action](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}})" >> $GITHUB_OUTPUT
-        fi
-        
-    - name: Leave comment
-      if: always()
-      uses: marocchino/sticky-pull-request-comment@v2
-      with:
-        header: Smoke tests status update
-        number: ${{ github.event.issue.number }}
-        message: "${{ steps.set_msg.outputs.msg }}"
-        recreate: true
+            - name: Cypress run
+              # Uses the official Cypress GitHub action https://github.com/cypress-io/github-action
+              uses: cypress-io/github-action@v6
+              with:
+                  # Records to Cypress Cloud
+                  # https://docs.cypress.io/guides/cloud/projects#Set-up-a-project-to-record
+                  record: true
+                  parallel: true # Runs test in parallel using settings above
+                  spec: cypress/e2e/smoke/*.js
+                  group: 'Smoke Tests'
+
+              env:
+                  # For recording and parallelization to work you must set your CYPRESS_RECORD_KEY
+                  # in GitHub repo → Settings → Secrets → Actions
+                  CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+                  # Creating a token https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token
+                  GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+                  # Set Base Url from client_payload.
+                  CYPRESS_BASE_URL: ${{ steps.capture_preview_url.outputs.url }}
+                  # Send PR details to Cypress test run
+                  COMMIT_INFO_MESSAGE: PR "${{ github.event.issue.number }}" in Repo "${{ github.repository }}" (v2)
+
+            - name: Set comments message
+              id: set_msg
+              if: always()
+              run: |
+                  # Using shell script to conditionally set the message
+                  if [[ "${{ job.status }}" == "success" ]]; then
+                    echo "msg=:rocket: Smoke test run (${{ matrix.containers }}) passed successfully!" >> $GITHUB_OUTPUT
+                  else
+                    echo "msg=:x: Smoke test run (${{ matrix.containers }}) failed. See logs for details: [Visit Action](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}})" >> $GITHUB_OUTPUT
+                  fi
+
+            - name: Leave comment
+              if: always()
+              uses: marocchino/sticky-pull-request-comment@v2
+              with:
+                  header: Smoke tests status update
+                  number: ${{ github.event.issue.number }}
+                  message: '${{ steps.set_msg.outputs.msg }}'
+                  recreate: true


### PR DESCRIPTION
Changes:

-   Capture cf pages preview URL to run lighthouse and smoke test

## Type of change

-   [ ] Bug fix
-   [ ] New feature
-   [x] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
