### PR TITLE
Prince/crowdin sync translation update

### DIFF
--- a/.github/workflows/translation-sync.yml
+++ b/.github/workflows/translation-sync.yml
@@ -30,5 +30,23 @@ jobs:
             - name: Push New Strings & Translations ⬆️
               run:  
                   crowdin upload sources -b master -T ${{ secrets.CROWDIN_API_KEY }}; crowdin upload translations -b master -T ${{ secrets.CROWDIN_API_KEY }}
-                
+            - name: Fetch,Sync & Push Strings to Crowdin
+              run: |
+                branch_name="crowdin_translations"
+
+                echo "Setting up Git identity"
+                git config --global user.name "DerivFE"
+                git config --global user.email "80095553+DerivFE@users.noreply.github.com"
+
+                echo "Checking out new branch [$branch_name]"
+                git checkout -b "$branch_name"
+
+                # Force push to this branch in case a previous run created it.
+                git push --set-upstream origin "$branch_name" -f
+
+                sudo apt install gh
+                gh auth login --with-token <<< ${{ github.token }}
+                gh pr close "$branch_name" || true
+                gh pr create --base "translators" --title "[translators] Update translators branch with master 📚" --head "binary-com:$branch_name" --body "This is an automated PR designed to keep the translators' branch up to date, ensuring that all newly added strings are available for translation."
+
 

--- a/.github/workflows/translation-sync.yml
+++ b/.github/workflows/translation-sync.yml
@@ -17,6 +17,12 @@ jobs:
     sync-translation:
         runs-on: ubuntu-latest
         steps:
+            - name: Check Branch Name
+              run: |
+                if [ "${{ github.event_name }}" == "push" ] && [ "${{ github.ref }}" == "refs/heads/new_translation_strings" ]; then
+                  echo "The branch recently merged to master is the branch came from this workflow, skipping further steps."
+                  exit 0
+                fi
             - name: Checkout 🛎️
               uses: actions/checkout@v2.3.1
             - name: Setup Node
@@ -32,21 +38,49 @@ jobs:
                   crowdin upload sources -b master -T ${{ secrets.CROWDIN_API_KEY }}; crowdin upload translations -b master -T ${{ secrets.CROWDIN_API_KEY }}
             - name: Fetch,Sync & Push Strings to Crowdin
               run: |
-                branch_name="crowdin_translations"
+                # Download new translated strings
+                echo 'Fetch Crowdin Master Translation ⬇️'
+                crowdin download -b  master -T ${{ secrets.CROWDIN_API_KEY }} && crowdin download -b master -l zh-CN -T ${{ secrets.CROWDIN_API_KEY }}
 
-                echo "Setting up Git identity"
-                git config --global user.name "DerivFE"
-                git config --global user.email "80095553+DerivFE@users.noreply.github.com"
+                if [ -n "$(git status --porcelain)" ]; then
+                  # New strings are added, create a PR to update the master
 
-                echo "Checking out new branch [$branch_name]"
-                git checkout -b "$branch_name"
+                  branch_name="new_translation_strings"
 
-                # Force push to this branch in case a previous run created it.
-                git push --set-upstream origin "$branch_name" -f
+                  echo "Setting up Git identity"
+                  git config --global user.name "DerivFE"
+                  git config --global user.email "80095553+DerivFE@users.noreply.github.com"
 
-                sudo apt install gh
-                gh auth login --with-token <<< ${{ github.token }}
-                gh pr close "$branch_name" || true
-                gh pr create --base "translators" --title "[translators] Update translators branch with master 📚" --head "binary-com:$branch_name" --body "This is an automated PR designed to keep the translators' branch up to date, ensuring that all newly added strings are available for translation."
+                  # Commit the newly downloaded files
+                  cd $(git rev-parse --show-toplevel)
+                  git add .
 
+                  echo "Checking out new branch [$branch_name]"
+                  git checkout -b "$branch_name"
+
+                  # Force push to this branch in case a previous run created it.
+                  git push --set-upstream origin "$branch_name" -f
+
+                  sudo apt install gh
+                  gh auth login --with-token <<< ${{ github.token }}
+                  gh pr close "$branch_name" || true
+                  gh pr create --base "master" --title "[Translations] New strings from crowdin 📚" --head "binary-com:$branch_name" --body "This is an automated pull request to fetch the newly translated strings from Crowdin to ensure that we do not overwrite the translations provided by the translation team before pushing our new strings."
+                fi
+
+                # Upload new strings to Crowdin
+                crowdin upload sources -b master -T ${{ secrets.CROWDIN_API_KEY }}; crowdin upload translations -b master -T ${{ secrets.CROWDIN_API_KEY }}
+            - name: Slack Notification 📣
+              uses: 8398a7/action-slack@v3
+              with:
+                  status: custom
+                  fields: workflow,job,commit,repo
+                  custom_payload: |
+                      {
+                        attachments: [{
+                          color: '${{ job.status }}' === 'success' ? 'good' : '${{ job.status }}' === 'failure' ? 'danger' : 'warning',
+                          text: `*[Deriv.com]*  New strings are pushed to crowdin master branch:(https://crowdin.com/project/deriv-com/content/files)`
+                        }]
+                      }
+              env:
+                  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_TRANSLATION }}
 


### PR DESCRIPTION
## Issue:
The Translation Team faces challenges when attempting to add translations to strings, as developers continuously push new strings. This results in the overriding of newly translated strings, compelling the team to restart their work.

## Solution: 
Updating the translation sync workflow to fetch newly translated strings and create a pull request (PR) ensures that we do not overwrite the Translation Team's changes with each push. Once the updated workflow is in place, we can safely push the new strings to Crowdin.

**`Note:`**
 An automated PR will be generated, including the newly translated strings. It is essential to merge this PR into the master branch. However, delaying the merge won't cause any issues, and it will still preserve the Translation Team's efforts in Crowdin without overwriting them.