### PR TITLE
[CRO] signup_provider is null in BigQuery for some 'started' action

### DIFF
--- a/src/features/hooks/use-signup-form/index.tsx
+++ b/src/features/hooks/use-signup-form/index.tsx
@@ -52,7 +52,11 @@ const useSignupForm = () => {
     })
 
     const onSignup = ({ email }: FormData) => {
-        Analytics?.trackEvent('ce_virtual_signup_form', { action: 'started', ...analyticsData })
+        Analytics?.trackEvent('ce_virtual_signup_form', {
+            action: 'started',
+            signup_provider: 'email',
+            ...analyticsData,
+        })
 
         const formatted_email = getVerifyEmailRequest(email)
         apiManager

--- a/src/features/pages/signup/form-container/form-social-buttons.tsx
+++ b/src/features/pages/signup/form-container/form-social-buttons.tsx
@@ -44,7 +44,7 @@ const FormSocialButtons = () => {
                 id="dm-signup-facebook"
                 onClick={() => {
                     Analytics?.trackEvent('ce_virtual_signup_form', {
-                        signup_provider: 'google',
+                        signup_provider: 'facebook',
                         ...analyticsData,
                     })
                     Login.initOneAll('facebook')
@@ -98,8 +98,9 @@ const FormSocialButtons = () => {
                             onClick={(event) => {
                                 event.preventDefault()
                                 Analytics?.trackEvent('ce_virtual_signup_form', {
-                                    signup_provider: 'email',
-                                    ...analyticsData,
+                                    action: 'go_to_login',
+                                    form_source: isBrowser() && window.location.hostname,
+                                    form_name: 'default_diel_deriv',
                                 })
                                 Login.redirectToLogin()
                             }}


### PR DESCRIPTION
Changes:

This pull request fixing the event track issue, when user trying to signup. We have to provide `signup_provider` data properly. To resolve this, some options were changed

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
