### PR TITLE
Konstantinos / Prevent Email Exposure in Signup Success Page URL

### DIFF
--- a/src/features/hooks/use-signup-form/index.tsx
+++ b/src/features/hooks/use-signup-form/index.tsx
@@ -66,11 +66,12 @@ const useSignupForm = () => {
             })
             .then(() => {
                 const locale = getLanguage()
-                const success_default_link = `signup-success?email=${email}`
+                const success_default_link = `signup-success`
                 const link_with_language = `${locale}/${success_default_link}`
                 const success_link = `/${
                     locale === 'en' ? success_default_link : link_with_language
                 }`
+                Cookies.set('user_email', email)
                 navigate(success_link, { replace: true })
             })
             .catch((reason) => {

--- a/src/pages/signup-success/index.tsx
+++ b/src/pages/signup-success/index.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import { navigate } from 'gatsby'
 import { Analytics } from '@deriv/analytics'
+import Cookies from 'js-cookie'
 import { getLanguage, isBrowser } from 'common/utility'
 import SignUpSuccessContainer from 'features/pages/signup-success'
 import { WithIntl } from 'components/localization'
@@ -14,12 +15,11 @@ const SignupSuccess = () => {
         form_name: 'default_diel_deriv',
     }
     useEffect(() => {
-        const params = new URLSearchParams(location.search)
-        const email = params.get('email')
+        const userEmail = Cookies.get('user_email') //
         const locale = getLanguage()
 
-        setRegisteredEmail(email?.replaceAll(' ', '+'))
-        if (!email) {
+        setRegisteredEmail(userEmail?.replaceAll(' ', '+'))
+        if (!userEmail) {
             if (locale !== 'en') navigate(`/${locale}/`, { replace: true })
             else {
                 navigate('/', { replace: true })


### PR DESCRIPTION
Changes:

As a user who has signed up for the platform, I want to ensure that my email address remains confidential and is not exposed in the URL of the Signup Success Page. ie: https://deriv.com/signup-success/?email=rest@gmail.com


## Type of change

-   [ ] Bug fix
-   [x] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
