### PR TITLE
Ako/ use ref_name instead of tag_name

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -89,7 +89,7 @@ jobs:
                   git clone https://github.com/binary-com/devops-ci-scripts
                   cd devops-ci-scripts/k8s-build_tools
                   echo "${{ env.CA_CRT }}" | base64 --decode > ca.crt
-                  ./release.sh deriv-com $GIT_TAG_NAME
+                  ./release.sh deriv-com ${{ github.ref_name }}
 
             - name: Slack Notification 📣
               uses: 8398a7/action-slack@v3

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -86,7 +86,7 @@ jobs:
                 git clone https://github.com/binary-com/devops-ci-scripts
                 cd devops-ci-scripts/k8s-build_tools
                 echo "${{ env.CA_CRT }}" | base64 --decode > ca.crt
-                ./release.sh deriv-com $GIT_TAG_NAME
+                ./release.sh deriv-com ${{ github.ref_name }}
 
             - name: Slack Notification 📣
               uses: 8398a7/action-slack@v3


### PR DESCRIPTION
Changes:

Since the TAG_NAME is not available on staging workflow i'm using ref_name instead of it here.

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
