### PR TITLE
Ako/ use SHA on staging workflow

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -86,7 +86,7 @@ jobs:
                 cd devops-ci-scripts/k8s-build_tools
                 echo "${{ env.CA_CRT }}" | base64 --decode > ca.crt
                 export CA="ca.crt"
-                ./release.sh deriv-com ${{ github.ref_name }}
+                ./release.sh deriv-com ${GITHUB_SHA}
 
             - name: Slack Notification 📣
               uses: 8398a7/action-slack@v3


### PR DESCRIPTION
Changes:

Since the github_ref_name is not valid, i'm using SHA on staging workflow.

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
