### PR TITLE
Amir/CRO-300/Add page tracking event

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -138,7 +138,9 @@ export const onClientEntry = () => {
     updateURLAsPerUserLanguage()
 }
 
-export const onRouteUpdate = () => {
+export const onRouteUpdate = ({ location }) => {
+    Analytics.pageView(location.pathname, 'Deriv.com')
+
     checkDomain()
     // can't be resolved by package function due the gatsby architecture
     window?._growthbook?.GrowthBook?.setURL(window.location.href)


### PR DESCRIPTION
Changes:

-   Add page tracking event on deriv.com
  - Previously on update of every route, we were sending this analytical data to GTM, now to track the whole user journey we are also using rudderstack events to send this data to different sources
  
  > Following is the screenshot from rudderstack, we can see the events are getting there on our rudderstack app
  
<img width="739" alt="image" src="https://github.com/binary-com/deriv-com/assets/129206554/aec2291a-a059-4bb3-988d-3994badd263d">


## Type of change

-   [ ] Bug fix
-   [x] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
