### PR TITLE
Konstantinos/DERC-2262/Datalayer issue

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -14,7 +14,7 @@ export const onRenderBody = ({ setHeadComponents }) => {
     const gtmTrackingId = process.env.GATSBY_GOOGLE_TAG_MANAGER_TRACKING_ID || ''
 
     setHeadComponents([
-        <Partytown key="partytown" forward={['dataLayer.push']} />,
+        <Partytown key="partytown" />,
         <script
             key="partytown-vanilla-config"
             type="text/partytown"


### PR DESCRIPTION
Changes:

Checking if the prop of Partytown causes the issue.

https://partytown.builder.io/forwarding-events

## Type of change

-   [ ] Bug fix
-   [ ] New feature
-   [x] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
