### PR TITLE
Konstantinos/FEQ-1007/Cannot read properties of undefined (reading 'on')

### DIFF
--- a/src/components/hooks/use-livechat.tsx
+++ b/src/components/hooks/use-livechat.tsx
@@ -16,7 +16,6 @@ export const useLivechat = (): [boolean, TLC_API] => {
 
     const loadLiveChatScript = (callback) => {
         const livechat_script = document.createElement('script')
-        livechat_script.type = 'text/partytown'
         livechat_script.innerHTML = `
         window.__lc = window.__lc || {};
         window.__lc.license = ${licence_key};


### PR DESCRIPTION
Changes:

Remove the type="text/partytown" from partytown as it's causing TrackJS logs on Cannot read properties of undefined (reading 'on') .

## Type of change

-   [ ] Bug fix
-   [ ] New feature
-   [x] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
