### PR TITLE
chore: remove datadog sessionreplay

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -108,6 +108,7 @@ export const onClientEntry = () => {
         env: 'production',
         version: '1.0.6',
         sessionSampleRate: 10,
+        sessionReplaySampleRate:0,
         trackResources: true,
         trackLongTasks: true,
         trackUserInteractions: true,

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -108,7 +108,7 @@ export const onClientEntry = () => {
         env: 'production',
         version: '1.0.6',
         sessionSampleRate: 10,
-        sessionReplaySampleRate:0,
+        sessionReplaySampleRate: 0,
         trackResources: true,
         trackLongTasks: true,
         trackUserInteractions: true,


### PR DESCRIPTION
Changes:

-   Set datadog session replay to 0

## Type of change

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
