### PR TITLE
Prince/Custom pages build on local environment

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -356,7 +356,7 @@ exports.onCreatePage = ({ page, actions }) => {
     deletePage(page)
 
     const pagesCategory = {
-        all: [],
+        all: [''],
         'no-affiliates': ['signup-affiliates', 'landing', 'ctrader', 'partners'],
         'no-help-centre': ['help-centre'],
         'no-tools': ['trader-tools'],
@@ -379,15 +379,10 @@ exports.onCreatePage = ({ page, actions }) => {
 
     const isMatch = regex.test(page.path)
 
-    console.log(`is_production: ${isProduction}`)
-    console.log(`pagesToBuild: ${pagesToBuild}`)
-
     if (isProduction) {
         return BuildPage(page, actions)
     } else {
-        if (isMatch) {
-            deletePage(page)
-        } else {
+        if (!isMatch || pagesToBuild === 'all') {
             console.log(`\x1b[32mcreating\x1b[0m [${pagesToBuild}] ${page.path}`)
             return BuildPage(page, actions)
         }

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -10,12 +10,9 @@ exports.onPreBuild = async () => {
     await copyLibFiles(path.join(__dirname, 'static', '~partytown'))
 }
 // Based upon https://github.com/gatsbyjs/gatsby/tree/master/examples/using-i18n
-exports.onCreatePage = ({ page, actions }) => {
-    const { createRedirect, createPage, deletePage } = actions
 
-    // First delete the incoming page that was automatically created by Gatsby
-    // So everything in src/pages/
-    deletePage(page)
+const BuildPage = (page, actions) => {
+    const { createRedirect, createPage } = actions
     const is_responsible_trading = /responsible/g.test(page.path)
     const is_contact_us = /contact_us/g.test(page.path)
     const is_careers = /careers/g.test(page.path)
@@ -348,6 +345,48 @@ exports.onCreatePage = ({ page, actions }) => {
 
         return current_page
     })
+}
+exports.onCreatePage = ({ page, actions }) => {
+    const { deletePage } = actions
+    const isProduction = process.env.GATSBY_ENV === 'production'
+    const pagesToBuild = process.env.GATSBY_BUILD_PAGES || 'all'
+
+    // First delete the incoming page that was automatically created by Gatsby
+    // So everything in src/pages/
+    deletePage(page)
+
+    const pagesCategory = {
+        all: [],
+        'no-affiliates': ['signup-affiliates', 'landing', 'ctrader', 'partners'],
+        'no-help-centre': ['help-centre'],
+        'no-tools': ['trader-tools'],
+        fast: [
+            'signup-affiliates',
+            'landing',
+            'ctrader',
+            'partners',
+            'help-centre',
+            'trader-tools',
+            'careers',
+        ],
+    }
+
+    const disallowedPages = pagesCategory[pagesToBuild] || []
+
+    const regex = new RegExp(`/${disallowedPages.join('|') + '|'}/g`)
+
+    const isMatch = regex.test(page.path)
+
+    if (isProduction) {
+        return BuildPage(page, actions)
+    } else {
+        if (isMatch) {
+            deletePage(page)
+        } else {
+            console.log(`\x1b[32mcreating\x1b[0m [${pagesToBuild}] ${page.path}`)
+            return BuildPage(page, actions)
+        }
+    }
 }
 
 const StylelintPlugin = require('stylelint-webpack-plugin')

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -379,6 +379,9 @@ exports.onCreatePage = ({ page, actions }) => {
 
     const isMatch = regex.test(page.path)
 
+    console.log(`is_production: ${isProduction}`)
+    console.log(`pagesToBuild: ${pagesToBuild}`)
+
     if (isProduction) {
         return BuildPage(page, actions)
     } else {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -368,6 +368,8 @@ exports.onCreatePage = ({ page, actions }) => {
             'help-centre',
             'trader-tools',
             'careers',
+            // 'markets',
+            // 'trade-types' Note: Feel free to adjust pages you want to skip building for faster local development
         ],
     }
 


### PR DESCRIPTION
### Changes

Allow developers to select pages they want to build for faster dev experience. 

### Requirements 

Add `GATSBY_BUILD_PAGES` in your `.env` `.env.development`

Options: `all` `no-affiliates` `no-help-centre` `no-tools` `fast`

Example: 
```
GATSBY_BUILD_PAGES=fast
```

**Note:** 
_Only `fast` mode can override the heap error we are facing, after few more investigations we will be able to identify which page is using up huge amount of memory_