### PR TITLE
Mitra/DERC-2411/hide app gallery and app store if it is not supported 

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -95,8 +95,9 @@ export const derivx_ios_url = 'https://apps.apple.com/us/app/deriv-x/id156333750
 export const derivx_android_url = 'https://play.google.com/store/apps/details?id=com.deriv.dx'
 export const derivx_huawei_url = 'https://appgallery.cloud.huawei.com/ag/n/app/C104633219'
 export const deriv_go_playstore_url = 'https://play.google.com/store/apps/details?id=com.deriv.app'
-export const deriv_go_huaweiappgallery_url = 'https://appgallery.huawei.com/#/app/C103801913'
-export const deriv_go_ios_url = 'https://apps.apple.com/my/app/deriv-go/id1550561298'
+export const deriv_go_huaweiappgallery_url = 'https://appgallery.huawei.com/app/C103801913'
+export const deriv_go_ios_url =
+    'https://apps.apple.com/my/app/deriv-go-online-trading-app/id1550561298'
 export const dmt5_web_browser_url =
     'https://metatraderweb.app/trade?servers=Deriv-Server-02&trade_server=Deriv-Server-02&login=100648979'
 export const deriv_mt5_app_url =

--- a/src/common/country-base.ts
+++ b/src/common/country-base.ts
@@ -456,7 +456,6 @@ export const not_avalable_appgallery_and_ios_countries = [
     'fk',
     'tf',
     'gg',
-    'cf',
     'im',
     'je',
     'ki',
@@ -473,13 +472,9 @@ export const not_avalable_appgallery_and_ios_countries = [
     'aq',
     'hm',
     'um',
-    'bi',
-    'et',
-    'gq',
-    'ls',
 ]
 
-export const not_available_iOS_countries = ['ad', 'ck', 'ps']
+export const not_available_iOS_countries = ['ad', 'ck', 'ps', 'et', 'bi', 'cf', 'gq', 'ls']
 
 export const not_available_ctrader_countries = [
     'as',

--- a/src/features/components/templates/footer/download.tsx
+++ b/src/features/components/templates/footer/download.tsx
@@ -10,6 +10,11 @@ import { StaticImage } from 'gatsby-plugin-image'
 import { CustomLink } from '@deriv-com/components'
 import { localize } from 'components/localization'
 import useRegion from 'components/hooks/use-region'
+import {
+    deriv_go_huaweiappgallery_url,
+    deriv_go_ios_url,
+    deriv_go_playstore_url,
+} from 'common/constants'
 
 const sharedClasses =
     'flex items-center justify-center gap-gap-md p-general-sm rounded-[4px] border-solid border-xs border-opacity-black-100'
@@ -21,7 +26,7 @@ const DownloadBadges = () => {
         <div className="flex flex-col gap-gap-md max-lg:flex-1">
             {is_appgallery_supported && is_appgallery_and_ios_supported && (
                 <CustomLink
-                    href="https://appgallery.huawei.com/app/C103801913"
+                    href={deriv_go_huaweiappgallery_url}
                     target="_blank"
                     className={clsx(sharedClasses, 'order-last')}
                 >
@@ -36,7 +41,7 @@ const DownloadBadges = () => {
                 </CustomLink>
             )}
             <CustomLink
-                href="https://play.google.com/store/apps/details?id=com.deriv.app"
+                href={deriv_go_playstore_url}
                 target="_blank"
                 className={clsx(sharedClasses)}
             >
@@ -50,11 +55,7 @@ const DownloadBadges = () => {
                 />
             </CustomLink>
             {is_ios_supported && is_appgallery_and_ios_supported && (
-                <CustomLink
-                    href="https://apps.apple.com/my/app/deriv-go-online-trading-app/id1550561298"
-                    target="_blank"
-                    className={clsx(sharedClasses)}
-                >
+                <CustomLink href={deriv_go_ios_url} target="_blank" className={clsx(sharedClasses)}>
                     <LabelPairedAppleLgIcon fill="#000000b8" />
                     <StaticImage
                         src="../../../../images/common/migration/footer/download-appstore.png"

--- a/src/features/components/templates/footer/download.tsx
+++ b/src/features/components/templates/footer/download.tsx
@@ -15,10 +15,11 @@ const sharedClasses =
     'flex items-center justify-center gap-gap-md p-general-sm rounded-[4px] border-solid border-xs border-opacity-black-100'
 
 const DownloadBadges = () => {
-    const { is_appgallery_supported, is_ios_supported } = useRegion()
+    const { is_appgallery_supported, is_ios_supported, is_appgallery_and_ios_supported } =
+        useRegion()
     return (
         <div className="flex flex-col gap-gap-md max-lg:flex-1">
-            {is_appgallery_supported && (
+            {is_appgallery_supported && is_appgallery_and_ios_supported && (
                 <CustomLink
                     href="https://appgallery.huawei.com/app/C103801913"
                     target="_blank"
@@ -48,7 +49,7 @@ const DownloadBadges = () => {
                     placeholder="none"
                 />
             </CustomLink>
-            {is_ios_supported && (
+            {is_ios_supported && is_appgallery_and_ios_supported && (
                 <CustomLink
                     href="https://apps.apple.com/my/app/deriv-go-online-trading-app/id1550561298"
                     target="_blank"

--- a/src/features/components/templates/footer/download.tsx
+++ b/src/features/components/templates/footer/download.tsx
@@ -9,27 +9,31 @@ import clsx from 'clsx'
 import { StaticImage } from 'gatsby-plugin-image'
 import { CustomLink } from '@deriv-com/components'
 import { localize } from 'components/localization'
+import useRegion from 'components/hooks/use-region'
 
 const sharedClasses =
     'flex items-center justify-center gap-gap-md p-general-sm rounded-[4px] border-solid border-xs border-opacity-black-100'
 
 const DownloadBadges = () => {
+    const { is_appgallery_supported, is_ios_supported } = useRegion()
     return (
         <div className="flex flex-col gap-gap-md max-lg:flex-1">
-            <CustomLink
-                href="https://appgallery.huawei.com/app/C103801913"
-                target="_blank"
-                className={clsx(sharedClasses, 'order-last')}
-            >
-                <LabelPairedHuaweiAppGalleryLgIcon fill="#000000b8" />
-                <StaticImage
-                    src="../../../../images/common/migration/footer/explore-appgallery.png"
-                    alt={localize('_t_explore it on appgallery_t_')}
-                    formats={['webp', 'auto']}
-                    width={90}
-                    placeholder="none"
-                />
-            </CustomLink>
+            {is_appgallery_supported && (
+                <CustomLink
+                    href="https://appgallery.huawei.com/app/C103801913"
+                    target="_blank"
+                    className={clsx(sharedClasses, 'order-last')}
+                >
+                    <LabelPairedHuaweiAppGalleryLgIcon fill="#000000b8" />
+                    <StaticImage
+                        src="../../../../images/common/migration/footer/explore-appgallery.png"
+                        alt={localize('_t_explore it on appgallery_t_')}
+                        formats={['webp', 'auto']}
+                        width={90}
+                        placeholder="none"
+                    />
+                </CustomLink>
+            )}
             <CustomLink
                 href="https://play.google.com/store/apps/details?id=com.deriv.app"
                 target="_blank"
@@ -44,20 +48,22 @@ const DownloadBadges = () => {
                     placeholder="none"
                 />
             </CustomLink>
-            <CustomLink
-                href="https://apps.apple.com/my/app/deriv-go-online-trading-app/id1550561298"
-                target="_blank"
-                className={clsx(sharedClasses)}
-            >
-                <LabelPairedAppleLgIcon fill="#000000b8" />
-                <StaticImage
-                    src="../../../../images/common/migration/footer/download-appstore.png"
-                    alt={localize('_t_download on the app store_t_')}
-                    formats={['webp', 'auto']}
-                    width={90}
-                    placeholder="none"
-                />
-            </CustomLink>
+            {is_ios_supported && (
+                <CustomLink
+                    href="https://apps.apple.com/my/app/deriv-go-online-trading-app/id1550561298"
+                    target="_blank"
+                    className={clsx(sharedClasses)}
+                >
+                    <LabelPairedAppleLgIcon fill="#000000b8" />
+                    <StaticImage
+                        src="../../../../images/common/migration/footer/download-appstore.png"
+                        alt={localize('_t_download on the app store_t_')}
+                        formats={['webp', 'auto']}
+                        width={90}
+                        placeholder="none"
+                    />
+                </CustomLink>
+            )}
         </div>
     )
 }


### PR DESCRIPTION

Changes:

- Hide app gallery and app store option in footer for deriv go for countries which is not supported

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
