### PR TITLE
disabling source-maps using gatsby-node.js file (webpack-config)

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -399,11 +399,10 @@ const style_lint_options = {
 
 exports.onCreateWebpackConfig = ({ stage, actions, loaders, getConfig }, { ...options }) => {
     const config = getConfig()
-    if (config.optimization) {
-        config.optimization.minimizer = [new TerserPlugin()]
-    }
+
     actions.setWebpackConfig({
         devtool: false,
+        ...(config.optimization ? { optimization: { minimizer: [new TerserPlugin()] } } : {}),
         plugins: [new StylelintPlugin({ ...style_lint_options, ...options })],
         resolve: {
             modules: [path.resolve(__dirname, 'src'), 'node_modules'],

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -402,22 +402,12 @@ exports.onCreateWebpackConfig = ({ stage, actions, loaders, getConfig }, { ...op
     if (config.optimization) {
         config.optimization.minimizer = [new TerserPlugin()]
     }
-    if (stage === 'build-html' || stage === 'develop-html') {
-        actions.setWebpackConfig({
-            module: {
-                rules: [
-                    {
-                        test: /analytics/,
-                        use: loaders.null(),
-                    },
-                ],
-            },
-        })
-    }
     actions.setWebpackConfig({
+        devtool: false,
         plugins: [new StylelintPlugin({ ...style_lint_options, ...options })],
         resolve: {
             modules: [path.resolve(__dirname, 'src'), 'node_modules'],
         },
+        ...((stage === 'build-html' || stage === 'develop-html') ? { module: { rules: [ { test: /analytics/, use: loaders.null() } ] } } : {}),
     })
 }


### PR DESCRIPTION
Changes:

-   disabling source-maps using gatsby-node.js file (webpack-config)

## Type of change

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
