### PR TITLE
Aswathy/DPROD-2811/Make faster builds for covering specific pages locally

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -350,7 +350,8 @@ exports.onCreatePage = ({ page, actions }) => {
     const { deletePage } = actions
     const isProduction = process.env.GATSBY_ENV === 'production'
     const pagesToBuild = process.env.GATSBY_BUILD_PAGES
-    const allowed_pages = ['', pagesToBuild?.split(',')]
+    const allowed_pages = ['', pagesToBuild.split(',')]
+
     const pages = allowed_pages.reduce((result, Item) => {
         if (Array.isArray(Item)) {
             // Flatten the nested array and add the '/' prefix

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -350,16 +350,25 @@ exports.onCreatePage = ({ page, actions }) => {
     const { deletePage } = actions
     const isProduction = process.env.GATSBY_ENV === 'production'
     const pagesToBuild = process.env.GATSBY_BUILD_PAGES
+    const allowed_pages = ['', pagesToBuild.split(',')]
+    const pages = allowed_pages.reduce((result, Item) => {
+        if (Array.isArray(Item)) {
+            // Flatten the nested array and add the '/' prefix
+            const nested_array = Item.map((subItem) => `/${subItem}/`)
+            return result.concat(nested_array)
+        } else {
+            // Add the '/' prefix for the root item
+            return result.concat(`/${Item}`)
+        }
+    }, [])
 
-    const allowed_pages = ['/', pagesToBuild]
+    console.log('allowed_pages', pages)
 
-    // First delete the incoming page that was automatically created by Gatsby
-    // So everything in src/pages/
     deletePage(page)
     if (isProduction) {
         return BuildPage(page, actions)
     } else {
-        if (allowed_pages.includes(page.path)) {
+        if (pages.includes(page.path)) {
             return BuildPage(page, actions)
         }
     }
@@ -367,6 +376,7 @@ exports.onCreatePage = ({ page, actions }) => {
 
 const StylelintPlugin = require('stylelint-webpack-plugin')
 const TerserPlugin = require('terser-webpack-plugin')
+
 const style_lint_options = {
     files: 'src/**/*.js',
     emitErrors: false,

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -350,7 +350,7 @@ exports.onCreatePage = ({ page, actions }) => {
     const { deletePage } = actions
     const isProduction = process.env.GATSBY_ENV === 'production'
     const pagesToBuild = process.env.GATSBY_BUILD_PAGES
-    const allowed_pages = ['', pagesToBuild.split(',')]
+    const allowed_pages = ['', pagesToBuild?.split(',')]
     const pages = allowed_pages.reduce((result, Item) => {
         if (Array.isArray(Item)) {
             // Flatten the nested array and add the '/' prefix
@@ -362,7 +362,7 @@ exports.onCreatePage = ({ page, actions }) => {
         }
     }, [])
 
-    console.log('allowed_pages', pages)
+    console.log('pages', pages)
 
     deletePage(page)
     if (isProduction) {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -350,28 +350,33 @@ exports.onCreatePage = ({ page, actions }) => {
     const { deletePage } = actions
     const isProduction = process.env.GATSBY_ENV === 'production'
     const pagesToBuild = process.env.GATSBY_BUILD_PAGES
-    const allowed_pages = ['', pagesToBuild.split(',')]
+    if (pagesToBuild) {
+        const pages_loaded = pagesToBuild.split(',')
+        const allowed_pages = ['', pages_loaded]
 
-    const pages = allowed_pages.reduce((result, Item) => {
-        if (Array.isArray(Item)) {
-            // Flatten the nested array and add the '/' prefix
-            const nested_array = Item.map((subItem) => `/${subItem}/`)
-            return result.concat(nested_array)
-        } else {
-            // Add the '/' prefix for the root item
-            return result.concat(`/${Item}`)
-        }
-    }, [])
+        const pages = allowed_pages.reduce((result, Item) => {
+            if (Array.isArray(Item)) {
+                // Flatten the nested array and add the '/' prefix
+                const nested_array = Item.map((subItem) => `/${subItem}/`)
+                return result.concat(nested_array)
+            } else {
+                // Add the '/' prefix for the root item
+                return result.concat(`/${Item}`)
+            }
+        }, [])
 
-    console.log('pages', pages)
+        console.log('pages', pages)
 
-    deletePage(page)
-    if (isProduction) {
-        return BuildPage(page, actions)
-    } else {
-        if (pages.includes(page.path)) {
+        deletePage(page)
+        if (isProduction) {
             return BuildPage(page, actions)
+        } else {
+            if (pages.includes(page.path)) {
+                return BuildPage(page, actions)
+            }
         }
+    } else {
+        return BuildPage(page, actions)
     }
 }
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -349,41 +349,17 @@ const BuildPage = (page, actions) => {
 exports.onCreatePage = ({ page, actions }) => {
     const { deletePage } = actions
     const isProduction = process.env.GATSBY_ENV === 'production'
-    const pagesToBuild = process.env.GATSBY_BUILD_PAGES || 'all'
+    const pagesToBuild = process.env.GATSBY_BUILD_PAGES
+
+    const allowed_pages = ['/', pagesToBuild]
 
     // First delete the incoming page that was automatically created by Gatsby
     // So everything in src/pages/
     deletePage(page)
-
-    const pagesCategory = {
-        all: [''],
-        'no-affiliates': ['signup-affiliates', 'landing', 'ctrader', 'partners'],
-        'no-help-centre': ['help-centre'],
-        'no-tools': ['trader-tools'],
-        fast: [
-            'signup-affiliates',
-            'landing',
-            'ctrader',
-            'partners',
-            'help-centre',
-            'trader-tools',
-            'careers',
-            // 'markets',
-            // 'trade-types' Note: Feel free to adjust pages you want to skip building for faster local development
-        ],
-    }
-
-    const disallowedPages = pagesCategory[pagesToBuild] || []
-
-    const regex = new RegExp(`/${disallowedPages.join('|') + '|'}/g`)
-
-    const isMatch = regex.test(page.path)
-
     if (isProduction) {
         return BuildPage(page, actions)
     } else {
-        if (!isMatch || pagesToBuild === 'all') {
-            console.log(`\x1b[32mcreating\x1b[0m [${pagesToBuild}] ${page.path}`)
+        if (allowed_pages.includes(page.path)) {
             return BuildPage(page, actions)
         }
     }


### PR DESCRIPTION
Changes:

-   Make faster builds for covering specific pages locally
- Make the page deploy supported from env
- Page listed in env are deployed seamlessly for localhost
- Add the required router path to the env.development  eg: `GATSBY_BUILD_PAGES='/markets/commodities/'`



## Type of change

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [x] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
