### PR TITLE
eduard/DPROD-2982/Disable JS source-maps for deriv-com

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -397,27 +397,16 @@ const style_lint_options = {
     lintDirtyModulesOnly: true,
 }
 
-exports.onCreateWebpackConfig = ({ stage, actions, loaders, getConfig }, { ...options }) => {
-    const config = getConfig()
-    if (config.optimization) {
-        config.optimization.minimizer = [new TerserPlugin()]
-    }
-    if (stage === 'build-html' || stage === 'develop-html') {
-        actions.setWebpackConfig({
-            module: {
-                rules: [
-                    {
-                        test: /analytics/,
-                        use: loaders.null(),
-                    },
-                ],
-            },
-        })
-    }
+exports.onCreateWebpackConfig = ({ stage, actions, loaders }, { ...options }) => {
     actions.setWebpackConfig({
+        devtool: false,
+        optimization: {
+            minimizer: [new TerserPlugin()],
+        },
         plugins: [new StylelintPlugin({ ...style_lint_options, ...options })],
         resolve: {
             modules: [path.resolve(__dirname, 'src'), 'node_modules'],
         },
+        ...((stage === 'build-html' || stage === 'develop-html') ? { module: { rules: [ { test: /analytics/, use: loaders.null() } ] } } : {}),
     })
 }


### PR DESCRIPTION
Changes:

-   source-maps disabling using webpack config on gatsby-node.js file

## Type of change

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
