### PR TITLE
Konstantinos/DPROD-2987/Tooltip arrow in trading specification page is a bit out of the position.

### DIFF
--- a/src/pages/trading-specification/components/_elements.tsx
+++ b/src/pages/trading-specification/components/_elements.tsx
@@ -181,7 +181,6 @@ export const TableHeaderCell = ({ text, infoIcon, toolTip }: TTableHeaderCell) =
                             arrowStyle={{ bottom: '-10px' }}
                             className="popover-arrow-container"
                             arrowClassName="popover-arrow"
-                            arr
                         >
                             <StyledToolTipContainer>
                                 <HeaderText

--- a/src/pages/trading-specification/components/_elements.tsx
+++ b/src/pages/trading-specification/components/_elements.tsx
@@ -166,7 +166,6 @@ export const TableHeaderCell = ({ text, infoIcon, toolTip }: TTableHeaderCell) =
                     isOpen={isInfoVisible}
                     positions={['top', 'right', 'bottom', 'left']}
                     padding={10}
-                    containerStyle={{ left: '-10px' }}
                     content={({ position, childRect, popoverRect }) => (
                         <ArrowContainer
                             style={{
@@ -182,6 +181,7 @@ export const TableHeaderCell = ({ text, infoIcon, toolTip }: TTableHeaderCell) =
                             arrowStyle={{ bottom: '-10px' }}
                             className="popover-arrow-container"
                             arrowClassName="popover-arrow"
+                            arr
                         >
                             <StyledToolTipContainer>
                                 <HeaderText


### PR DESCRIPTION
Changes:

Fix tooltip arrow in trading specification page being a bit out of the position.

## Type of change

-   [ ] Bug fix
-   [ ] New feature
-   [x] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
