### PR TITLE
Mitra/Fix duplicate text due to wrong classname

### DIFF
--- a/src/pages/help-centre/components/_side-tab.tsx
+++ b/src/pages/help-centre/components/_side-tab.tsx
@@ -69,7 +69,7 @@ const SideTab = ({ children, tab_header, data }: SideTabType) => {
 
     return (
         <Wrapper>
-            <div className={dclsx('visible-larger-than-tablet')}>
+            <div className={dclsx('at-visible-larger-than-tablet')}>
                 <Header max_width="38.4rem" size="3.6rem" mb="4rem">
                     <Localize translate_text={tab_header} />
                 </Header>

--- a/src/pages/markets/instruments/_crash-boom.tsx
+++ b/src/pages/markets/instruments/_crash-boom.tsx
@@ -26,7 +26,7 @@ const CrashBoom = () => {
                         mb="4x"
                         weight="bold"
                         size="small"
-                        className={dclsx('visible-larger-than-phone')}
+                        className={dclsx('at-visible-larger-than-phone')}
                     >
                         <Localize translate_text={'_t_Deriv MT5 and Deriv X:_t_'} />
                     </Typography.Paragraph>
@@ -34,7 +34,7 @@ const CrashBoom = () => {
                         mb="4x"
                         weight="bold"
                         size="xs"
-                        className={dclsx('visible-phone-only')}
+                        className={dclsx('at-visible-phone-only')}
                     >
                         <Localize translate_text={'_t_Deriv MT5 and Deriv X:_t_'} />
                     </Typography.Paragraph>
@@ -47,7 +47,7 @@ const CrashBoom = () => {
                         mt="8x"
                         weight="bold"
                         size="small"
-                        className={dclsx('visible-larger-than-phone')}
+                        className={dclsx('at-visible-larger-than-phone')}
                     >
                         <Localize translate_text={'_t_Deriv cTrader:_t_'} />
                     </Typography.Paragraph>
@@ -56,7 +56,7 @@ const CrashBoom = () => {
                         mt="8x"
                         weight="bold"
                         size="xs"
-                        className={dclsx('visible-phone-only')}
+                        className={dclsx('at-visible-phone-only')}
                     >
                         <Localize translate_text={'_t_Deriv cTrader:_t_'} />
                     </Typography.Paragraph>

--- a/src/pages/markets/instruments/_dex-indices.tsx
+++ b/src/pages/markets/instruments/_dex-indices.tsx
@@ -12,7 +12,7 @@ const DexIndices = () => {
                 mb="4x"
                 weight="bold"
                 size="small"
-                className={dclsx('visible-larger-than-phone')}
+                className={dclsx('at-visible-larger-than-phone')}
             >
                 <Localize translate_text={'_t_Deriv MT5 and Deriv X:_t_'} />
             </Typography.Paragraph>
@@ -20,7 +20,7 @@ const DexIndices = () => {
                 mb="4x"
                 weight="bold"
                 size="xs"
-                className={dclsx('visible-phone-only')}
+                className={dclsx('at-visible-phone-only')}
             >
                 <Localize translate_text={'_t_Deriv MT5 and Deriv X:_t_'} />
             </Typography.Paragraph>

--- a/src/pages/markets/instruments/_drift_switch_indices.tsx
+++ b/src/pages/markets/instruments/_drift_switch_indices.tsx
@@ -12,7 +12,7 @@ const DriftSwitchIndices = () => {
                 mb="4x"
                 weight="bold"
                 size="small"
-                className={dclsx('visible-larger-than-phone')}
+                className={dclsx('at-visible-larger-than-phone')}
             >
                 <Localize translate_text={'_t_Deriv MT5 and Deriv X:_t_'} />
             </Typography.Paragraph>
@@ -20,7 +20,7 @@ const DriftSwitchIndices = () => {
                 mb="4x"
                 weight="bold"
                 size="xs"
-                className={dclsx('visible-phone-only')}
+                className={dclsx('at-visible-phone-only')}
             >
                 <Localize translate_text={'_t_Deriv MT5 and Deriv X:_t_'} />
             </Typography.Paragraph>

--- a/src/pages/markets/instruments/_jump_indices.tsx
+++ b/src/pages/markets/instruments/_jump_indices.tsx
@@ -18,7 +18,7 @@ const JumpIndices = ({ is_cfd }: JumpIndicesProps) => {
                         mb="4x"
                         weight="bold"
                         size="small"
-                        className={dclsx('visible-larger-than-phone')}
+                        className={dclsx('at-visible-larger-than-phone')}
                     >
                         <Localize translate_text={'_t_Deriv MT5 and Deriv X:_t_'} />
                     </Typography.Paragraph>
@@ -26,7 +26,7 @@ const JumpIndices = ({ is_cfd }: JumpIndicesProps) => {
                         mb="4x"
                         weight="bold"
                         size="xs"
-                        className={dclsx('visible-phone-only')}
+                        className={dclsx('at-visible-phone-only')}
                     >
                         <Localize translate_text={'_t_Deriv MT5 and Deriv X:_t_'} />
                     </Typography.Paragraph>

--- a/src/pages/markets/instruments/_range-break.tsx
+++ b/src/pages/markets/instruments/_range-break.tsx
@@ -12,7 +12,7 @@ const RangeBreak = () => {
                 mb="4x"
                 weight="bold"
                 size="small"
-                className={dclsx('visible-larger-than-phone')}
+                className={dclsx('at-visible-larger-than-phone')}
             >
                 <Localize translate_text={'_t_Deriv MT5 and Deriv X:_t_'} />
             </Typography.Paragraph>
@@ -20,7 +20,7 @@ const RangeBreak = () => {
                 mb="4x"
                 weight="bold"
                 size="xs"
-                className={dclsx('visible-phone-only')}
+                className={dclsx('at-visible-phone-only')}
             >
                 <Localize translate_text={'_t_Deriv MT5 and Deriv X:_t_'} />
             </Typography.Paragraph>

--- a/src/pages/markets/instruments/_step-indices.tsx
+++ b/src/pages/markets/instruments/_step-indices.tsx
@@ -18,7 +18,7 @@ const StepIndices = ({ is_cfd }: StepIndicesProps) => {
                         mb="4x"
                         weight="bold"
                         size="small"
-                        className={dclsx('visible-larger-than-phone')}
+                        className={dclsx('at-visible-larger-than-phone')}
                     >
                         <Localize translate_text={'_t_Deriv MT5 and Deriv X:_t_'} />
                     </Typography.Paragraph>
@@ -26,7 +26,7 @@ const StepIndices = ({ is_cfd }: StepIndicesProps) => {
                         mb="4x"
                         weight="bold"
                         size="xs"
-                        className={dclsx('visible-phone-only')}
+                        className={dclsx('at-visible-phone-only')}
                     >
                         <Localize translate_text={'_t_Deriv MT5 and Deriv X:_t_'} />
                     </Typography.Paragraph>

--- a/src/pages/markets/instruments/_volatility-indices.tsx
+++ b/src/pages/markets/instruments/_volatility-indices.tsx
@@ -27,7 +27,7 @@ const VolatilityIndices = () => {
                         mb="4x"
                         weight="bold"
                         size="small"
-                        className={dclsx('visible-larger-than-phone')}
+                        className={dclsx('at-visible-larger-than-phone')}
                     >
                         <Localize translate_text={'_t_Deriv MT5 and Deriv X:_t_'} />
                     </Typography.Paragraph>
@@ -35,7 +35,7 @@ const VolatilityIndices = () => {
                         mb="4x"
                         weight="bold"
                         size="xs"
-                        className={dclsx('visible-phone-only')}
+                        className={dclsx('at-visible-phone-only')}
                     >
                         <Localize translate_text={'_t_Deriv MT5 and Deriv X:_t_'} />
                     </Typography.Paragraph>
@@ -49,7 +49,7 @@ const VolatilityIndices = () => {
                         mt="8x"
                         weight="bold"
                         size="small"
-                        className={dclsx('visible-larger-than-phone')}
+                        className={dclsx('at-visible-larger-than-phone')}
                     >
                         <Localize translate_text={'_t_Deriv cTrader:_t_'} />
                     </Typography.Paragraph>
@@ -58,7 +58,7 @@ const VolatilityIndices = () => {
                         mt="8x"
                         weight="bold"
                         size="xs"
-                        className={dclsx('visible-phone-only')}
+                        className={dclsx('at-visible-phone-only')}
                     >
                         <Localize translate_text={'_t_Deriv cTrader:_t_'} />
                     </Typography.Paragraph>


### PR DESCRIPTION
Changes:

- add the missed prefix for the classname 

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
