### PR TITLE
habib/DPROD-3504/Bundle-seperation for node_modules

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -429,14 +429,19 @@ exports.onCreateWebpackConfig = ({ stage, actions, loaders, getConfig }, { ...op
             splitChunks: {
                 chunks: 'all',
                 cacheGroups: {
-                    default: false,
-                    vendors: false,
-                    // Merge all js, ts, and tsx files  into one bundle
-                    all: {
-                        test: /\.(js|ts|tsx)$/,
-                        name: 'bundle',
-                        chunks: 'all',
-                    },
+                  vendor: {
+                    test: /[\\/]node_modules[\\/]/,
+                    name: 'vendors',
+                    chunks: 'all',
+                    priority: -10,
+                  },
+                  bundle: {
+                    test: /\.(js|ts|tsx)$/,
+                    name: 'bundle',
+                    chunks: 'all',
+                    priority: -20,
+                    enforce: true,
+                  },
                 },
             },
             mangleExports: 'size',


### PR DESCRIPTION
Changes:

-   Bundle-seperation for node_modules and other tsx/ts/js files

## Type of change

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
