### PR TITLE
Fasih/DPROD-3591/Add lazy loading attribute in payment icons

### DIFF
--- a/src/features/pages/home/fast-payment/data.tsx
+++ b/src/features/pages/home/fast-payment/data.tsx
@@ -8,7 +8,7 @@ const toImage = (path: string, alt: string) => (
         height={80}
         width={128}
         className="max-w-[128px] h-[80px]"
-        loading="eager"
+        loading="lazy"
     />
 )
 


### PR DESCRIPTION
Changes:

-   Add lazy loading attribute in payment icons
<img width="1792" alt="Screenshot 2024-02-22 at 2 34 31 PM" src="https://github.com/binary-com/deriv-com/assets/121229483/770fc0ea-5150-4bb7-8b26-69b646254a3a">

## Type of change

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [x] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
