### PR TITLE
Update smoketests.yml - change e2e skip term

### DIFF
--- a/.github/workflows/smoketests.yml
+++ b/.github/workflows/smoketests.yml
@@ -48,7 +48,7 @@ jobs:
 
             - name: Cypress run
               # Uses the official Cypress GitHub action https://github.com/cypress-io/github-action
-              if: "!contains(steps.pr_information.outputs.branch_name, 'quill')"
+              if: "!contains(steps.pr_information.outputs.branch_name, 'skipsm')"
               uses: cypress-io/github-action@v6
               with:
                   # Records to Cypress Cloud
@@ -71,7 +71,7 @@ jobs:
 
             - name: Set comments message
               id: set_msg
-              if: always() && !contains(steps.pr_information.outputs.branch_name, 'quill')
+              if: always() && !contains(steps.pr_information.outputs.branch_name, 'skipsm')
               run: |
                   # Using shell script to conditionally set the message
                   if [[ "${{ job.status }}" == "success" ]]; then
@@ -81,7 +81,7 @@ jobs:
                   fi
 
             - name: Leave comment
-              if: always() && !contains(steps.pr_information.outputs.branch_name, 'quill')
+              if: always() && !contains(steps.pr_information.outputs.branch_name, 'skipsm')
               uses: marocchino/sticky-pull-request-comment@v2
               with:
                   header: Smoke tests status update


### PR DESCRIPTION
If the term 'skipsm' is specified in the branch name then skip the e2e tests (used to be 'quill').

This is because the dev knows they are making radical change which will need the tests to be modified at a later date.

Changes:

-   ...

## Type of change

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
