### PR TITLE
Updated smoketest workflows

### DIFF
--- a/.github/workflows/smoketests-eu.yml
+++ b/.github/workflows/smoketests-eu.yml
@@ -28,10 +28,10 @@ jobs:
               id: download-artifact
               uses: actions/download-artifact@7a1cd3216ca9260cd8022db641d960b1db4d1be4
               with:
-                  workflow_conclusion: success
-                  run_id: ${{ github.event.workflow_run.id }}
+                  run-id: ${{ github.event.workflow_run.id }}
                   name: 'pr-${{ github.event.workflow_run.id }}'
                   path: .pr
+                  github-token: ${{ secrets.GITHUB_TOKEN }} 
 
             - name: Retrieve pull request
               id: pr_information

--- a/.github/workflows/smoketests-row.yml
+++ b/.github/workflows/smoketests-row.yml
@@ -28,10 +28,10 @@ jobs:
               id: download-artifact
               uses: actions/download-artifact@7a1cd3216ca9260cd8022db641d960b1db4d1be4
               with:
-                  workflow_conclusion: success
-                  run_id: ${{ github.event.workflow_run.id }}
+                  run-id: ${{ github.event.workflow_run.id }}
                   name: 'pr-${{ github.event.workflow_run.id }}'
                   path: .pr
+                  github-token: ${{ secrets.GITHUB_TOKEN }} 
 
             - name: Retrieve pull request
               id: pr_information


### PR DESCRIPTION
**Changes:**

- Updated smoke test workflows to meet the requirements for https://github.com/actions/download-artifact action.
- Passing the workflow token as it is needed because we are fetching artifacts from another workflow run. [REF](https://github.com/actions/download-artifact#:~:text=current%20workflow%20run.-,github%2Dtoken%3A,-%23%20The%20repository)

## Type of change

-   [X] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
