### PR TITLE
fix: Prototype pollution found deriv-com via utils

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
                 "gatsby-plugin-postcss": "^6.12.0",
                 "gatsby-plugin-styled-components": "^6.12.0",
                 "gatsby-plugin-webpack-bundle-analyser-v2": "^1.1.32",
-                "gh-pages": "^3.2.3",
+                "gh-pages": "^5.0.0",
                 "husky": "^7.0.4",
                 "identity-obj-proxy": "^3.0.0",
                 "jest": "^29.7.0",
@@ -2209,16 +2209,6 @@
             "version": "0.2.3",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/@builder.io/partytown": {
-            "version": "0.8.2",
-            "license": "MIT",
-            "bin": {
-                "partytown": "bin/partytown.cjs"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
         },
         "node_modules/@cnakazawa/watch": {
             "version": "1.0.4",
@@ -21829,9 +21819,10 @@
             "license": "MIT"
         },
         "node_modules/email-addresses": {
-            "version": "3.1.0",
-            "dev": true,
-            "license": "MIT"
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/email-addresses/-/email-addresses-5.0.0.tgz",
+            "integrity": "sha512-4OIPYlA6JXqtVn8zpHpGiI7vE6EQOAg16aGnDMIAlZVinnoZ8208tW1hAbjWydgN/4PLTT9q+O1K6AH/vALJGw==",
+            "dev": true
         },
         "node_modules/embla-carousel": {
             "version": "6.2.0",
@@ -27009,13 +27000,14 @@
             }
         },
         "node_modules/gh-pages": {
-            "version": "3.2.3",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/gh-pages/-/gh-pages-5.0.0.tgz",
+            "integrity": "sha512-Nqp1SjkPIB94Xw/3yYNTUL+G2dxlhjvv1zeN/4kMC1jfViTEqhtVz/Ba1zSXHuvXCN9ADNS1dN4r5/J/nZWEQQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "async": "^2.6.1",
+                "async": "^3.2.4",
                 "commander": "^2.18.0",
-                "email-addresses": "^3.0.1",
+                "email-addresses": "^5.0.0",
                 "filenamify": "^4.3.0",
                 "find-cache-dir": "^3.3.1",
                 "fs-extra": "^8.1.0",
@@ -27041,12 +27033,10 @@
             }
         },
         "node_modules/gh-pages/node_modules/async": {
-            "version": "2.6.4",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "lodash": "^4.17.14"
-            }
+            "version": "3.2.5",
+            "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
+            "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg==",
+            "dev": true
         },
         "node_modules/gh-pages/node_modules/commander": {
             "version": "2.20.3",
@@ -47989,7 +47979,6 @@
             "license": "ISC",
             "dependencies": {
                 "@artsy/fresnel": "^6.2.1",
-                "@builder.io/partytown": "^0.8.1",
                 "@deriv-com/analytics": "^1.5.0",
                 "@deriv-com/blocks": "^0.118.0",
                 "@deriv-com/components": "^0.59.0",


### PR DESCRIPTION
Prototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as __proto__, constructor and prototype. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.

Changes:

-   ...

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [x] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
