### PR TITLE
Fix gh action vulnerable env

### DIFF
--- a/.github/workflows/production-eu.yml
+++ b/.github/workflows/production-eu.yml
@@ -125,7 +125,7 @@ jobs:
                     run: |
                         git clone https://github.com/binary-com/devops-ci-scripts
                         cd devops-ci-scripts/k8s-build_tools
-                        echo "${{ env.CA_CRT }}" | base64 --decode > ca.crt
+                        echo "$CA_CRT" | base64 --decode > ca.crt
                         export CA="ca.crt"
                         ./release.sh deriv-com ${{ github.ref_name }}
     

--- a/.github/workflows/production-row.yml
+++ b/.github/workflows/production-row.yml
@@ -126,7 +126,7 @@ jobs:
                     run: |
                         git clone https://github.com/binary-com/devops-ci-scripts
                         cd devops-ci-scripts/k8s-build_tools
-                        echo "${{ env.CA_CRT }}" | base64 --decode > ca.crt
+                        echo "$CA_CRT" | base64 --decode > ca.crt
                         export CA="ca.crt"
                         ./release.sh deriv-com ${{ github.ref_name }}
     

--- a/.github/workflows/staging-eu.yml
+++ b/.github/workflows/staging-eu.yml
@@ -90,7 +90,7 @@ jobs:
               run: |
                   git clone https://github.com/binary-com/devops-ci-scripts
                   cd devops-ci-scripts/k8s-build_tools
-                  echo "${{ env.CA_CRT }}" | base64 --decode > ca.crt
+                  echo "$CA_CRT" | base64 --decode > ca.crt
                   export CA="ca.crt"
                   ./release.sh deriv-com ${GITHUB_SHA}
 

--- a/.github/workflows/staging-row.yml
+++ b/.github/workflows/staging-row.yml
@@ -90,7 +90,7 @@ jobs:
               run: |
                   git clone https://github.com/binary-com/devops-ci-scripts
                   cd devops-ci-scripts/k8s-build_tools
-                  echo "${{ env.CA_CRT }}" | base64 --decode > ca.crt
+                  echo "$CA_CRT" | base64 --decode > ca.crt
                   export CA="ca.crt"
                   ./release.sh deriv-com ${GITHUB_SHA}
 


### PR DESCRIPTION
Changes:

-   Fixing vulnerable usage of `env.` variable in github action workflows - `${{ env.CA_CRT }}`
    - .github/workflows/production-eu.yml
    - .github/workflows/production-row.yml
    - .github/workflows/staging-eu.yml
    - .github/workflows/staging-row.yml
- [WikiJS Doc](https://wikijs.deriv.cloud/en/Security/product-security/github-workflow-scanner#:~:text=workflow_audit_6%20%2D%20Risky%20Contexts%20and%20Vulnerable%20ENV%20Review%20%2D%20Check%20for%20potential%20script%20injections) 
## Type of change

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
